### PR TITLE
feat: fix learning feedback loops

### DIFF
--- a/backend/analysis/autonomous_engine.py
+++ b/backend/analysis/autonomous_engine.py
@@ -24,6 +24,7 @@ from uuid import uuid4
 
 from database import async_session_factory  # type: ignore[import-not-found]
 from models.deep_insight import DeepInsight, InsightType, InsightAction  # type: ignore[import-not-found]
+from models.insight_research_context import InsightResearchContext  # type: ignore[import-not-found]
 
 from analysis.agents.macro_scanner import (  # type: ignore[import-not-found]
     MacroScanner,
@@ -99,6 +100,7 @@ from analysis.context_builder import MarketContextBuilder  # type: ignore[import
 from analysis.memory_service import InstitutionalMemoryService  # type: ignore[import-not-found]
 from analysis.pattern_extractor import PatternExtractor  # type: ignore[import-not-found]
 from analysis.outcome_tracker import InsightOutcomeTracker  # type: ignore[import-not-found]
+from analysis.confidence_adjuster import ConfidenceAdjuster  # type: ignore[import-not-found]
 from llm.client_pool import pool_query_llm, LLMQueryResult  # type: ignore[import-not-found]
 
 # Optional alternative data sources (availability flags)
@@ -841,7 +843,7 @@ class AutonomousDeepEngine:
         await self._update_task_progress(task_id, "synthesis", 90, "Synthesizing insights...")
         if self._run_metrics:
             self._run_metrics.start_phase("synthesis")
-        insights_data = await self._run_synthesis_with_heatmap(
+        insights_data, synthesis_raw_response = await self._run_synthesis_with_heatmap(
             analyst_reports=analyst_reports,
             macro_context=macro_result,
             heatmap_analysis=heatmap_analysis_result,
@@ -860,6 +862,8 @@ class AutonomousDeepEngine:
                 macro_result,
                 heatmap_analysis_result,
                 pre_context=pre_context,
+                analyst_reports=analyst_reports,
+                synthesis_raw_response=synthesis_raw_response,
             )
             result.insights = saved_insights
 
@@ -1149,7 +1153,7 @@ class AutonomousDeepEngine:
         heatmap_analysis: HeatmapAnalysis,
         max_insights: int,
         portfolio_holdings: dict[str, dict[str, float]] | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], str]:
         """Run Phase 5: Synthesis Lead with heatmap context.
 
         Args:
@@ -1160,7 +1164,7 @@ class AutonomousDeepEngine:
             portfolio_holdings: Optional dict of user portfolio holdings.
 
         Returns:
-            List of insight dictionaries.
+            Tuple of (list of insight dictionaries, raw LLM response).
         """
         # Build enhanced synthesis context
         async with async_session_factory() as session:
@@ -1168,9 +1172,10 @@ class AutonomousDeepEngine:
 
             # Get patterns and track record
             symbols = list(analyst_reports.keys())[:10]
+            current_conditions = self._extract_conditions_from_analyst_reports(analyst_reports)
             patterns = await memory_service.get_relevant_patterns(
                 symbols=symbols,
-                current_conditions={},
+                current_conditions=current_conditions,
             )
             track_record = await memory_service.get_insight_track_record()
 
@@ -1206,7 +1211,38 @@ class AutonomousDeepEngine:
         # Query LLM
         response = await self._query_llm(enhanced_prompt, full_context, "synthesis", "synthesis")
 
-        return parse_synthesis_response(response)
+        try:
+            insights = parse_synthesis_response(response)
+        except Exception as parse_err:
+            logger.error(f"[AUTO] Failed to parse synthesis response: {parse_err} | preview: {response[:500]}")
+            insights = []
+
+        # Adjust confidence based on historical track record
+        try:
+            async with async_session_factory() as adj_session:
+                memory_service_adj = InstitutionalMemoryService(adj_session)
+                adjuster = ConfidenceAdjuster(adj_session, memory_service_adj)
+                for insight_dict in insights:
+                    try:
+                        result = await adjuster.adjust_confidence(
+                            base_confidence=float(insight_dict.get("confidence", 0.5)),
+                            insight_type=insight_dict.get("insight_type", "opportunity"),
+                            action_type=insight_dict.get("action", "HOLD"),
+                            symbols=[insight_dict["primary_symbol"]] if insight_dict.get("primary_symbol") else None,
+                        )
+                        old_conf = insight_dict.get("confidence", 0.5)
+                        insight_dict["confidence"] = result["adjusted_confidence"]
+                        if result["adjusted_confidence"] != old_conf:
+                            logger.info(
+                                f"[AUTO] Confidence adjusted for {insight_dict.get('primary_symbol')}: "
+                                f"{old_conf:.2f} -> {result['adjusted_confidence']:.2f}"
+                            )
+                    except Exception as adj_err:
+                        logger.warning(f"[AUTO] Confidence adjustment failed: {adj_err}")
+        except Exception as e:
+            logger.warning(f"[AUTO] Confidence adjustment phase failed: {e}")
+
+        return insights, response
 
     def _build_heatmap_autonomous_synthesis_context(
         self,
@@ -1298,6 +1334,142 @@ class AutonomousDeepEngine:
             }
         return None
 
+    def _create_research_context(
+        self,
+        insight: DeepInsight,
+        analyst_reports: dict[str, dict[str, Any]],
+        macro_result: MacroScanResult,
+        synthesis_raw_response: str | None = None,
+        total_insights_count: int = 0,
+        pre_context: dict[str, Any] | None = None,
+        heatmap_analysis: HeatmapAnalysis | None = None,
+        sector_result: SectorRotationResult | None = None,
+    ) -> InsightResearchContext:
+        """Create an InsightResearchContext for an autonomous engine insight.
+
+        Maps the per-symbol analyst report structure to the flat schema
+        expected by InsightResearchContext, using the insight's primary_symbol
+        to select the relevant reports.
+
+        Args:
+            insight: The parent DeepInsight.
+            analyst_reports: Per-symbol analyst reports dict.
+            macro_result: Global macro scan results.
+            synthesis_raw_response: Raw LLM synthesis response text.
+            total_insights_count: Total insights generated in this run.
+            pre_context: Market context dict (heatmap pipeline).
+            heatmap_analysis: Heatmap analysis results (heatmap pipeline).
+            sector_result: Sector rotation results (legacy pipeline).
+
+        Returns:
+            InsightResearchContext model instance.
+        """
+        symbol = insight.primary_symbol
+        symbol_reports = analyst_reports.get(symbol, {}) if symbol else {}
+
+        def clean_report(report: dict[str, Any] | None) -> dict[str, Any] | None:
+            if not report or "error" in report:
+                return None
+            return {k: v for k, v in report.items() if not k.startswith("_")}
+
+        # Extract per-symbol analyst reports
+        technical_report = clean_report(symbol_reports.get("technical"))
+        sector_report = clean_report(symbol_reports.get("sector"))
+        risk_report = clean_report(symbol_reports.get("risk"))
+
+        # Macro is global in autonomous engine
+        macro_report = macro_result.to_dict() if macro_result else None
+
+        # Correlation not run in autonomous pipeline
+        correlation_report = None
+
+        # Market context snapshots from pre_context (heatmap pipeline)
+        market_summary_snapshot = pre_context.get("market_summary") if pre_context else None
+        sector_performance_snapshot = pre_context.get("sector_performance") if pre_context else None
+        economic_indicators_snapshot = pre_context.get("economic_indicators") if pre_context else None
+
+        # Build synthesis summary
+        analyst_names: set[str] = set()
+        for sym_reports in analyst_reports.values():
+            if isinstance(sym_reports, dict):
+                for name, report in sym_reports.items():
+                    if isinstance(report, dict) and "error" not in report:
+                        analyst_names.add(name)
+        synthesis_summary: dict[str, Any] = {
+            "insight_count": total_insights_count,
+            "analysts_included": sorted(analyst_names),
+            "pipeline": "heatmap" if heatmap_analysis else "legacy",
+        }
+
+        # Build condensed analysts summary
+        summaries: list[str] = []
+        if technical_report:
+            finding = technical_report.get("market_structure", "N/A")
+            conf = technical_report.get("confidence", 0)
+            summaries.append(f"Technical({symbol}): {finding} (conf: {conf:.0%})")
+        summaries.append(f"Macro: {macro_result.market_regime}")
+        if sector_report:
+            phase = sector_report.get("market_phase", "N/A")
+            summaries.append(f"Sector: {phase}")
+        if risk_report:
+            vol_regime = risk_report.get("volatility_regime", {})
+            vol_name = vol_regime.get("name", "N/A") if isinstance(vol_regime, dict) else "N/A"
+            summaries.append(f"Risk: {vol_name} volatility")
+        if heatmap_analysis:
+            summaries.append(f"Heatmap: {heatmap_analysis.overview[:80]}")
+        analysts_summary = " | ".join(summaries)[:2000]
+
+        # Build key data points
+        key_data_points: list[str] = []
+        key_data_points.append(f"regime:{macro_result.market_regime}")
+        if pre_context:
+            market_summary = pre_context.get("market_summary", {})
+            spy_data = market_summary.get("SPY", {})
+            if spy_data:
+                change = spy_data.get("change_percent", 0)
+                key_data_points.append(f"SPY_change={change:+.2f}%")
+        if technical_report:
+            for finding in (technical_report.get("findings") or [])[:3]:
+                if isinstance(finding, dict):
+                    rsi = finding.get("rsi")
+                    sym = finding.get("symbol", symbol)
+                    if rsi:
+                        key_data_points.append(f"RSI:{sym}={rsi:.1f}")
+
+        # Estimate token count
+        total_chars = len(str(symbol_reports)) + len(str(synthesis_raw_response or ""))
+        estimated_token_count = total_chars // 4
+
+        # Build successful analysts list
+        successful_analysts = [
+            f"{sym}:{analyst_name}"
+            for sym, reports in analyst_reports.items()
+            for analyst_name, report in (reports.items() if isinstance(reports, dict) else [])
+            if isinstance(report, dict) and "error" not in report
+        ]
+
+        return InsightResearchContext(
+            deep_insight=insight,
+            schema_version="1.0",
+            technical_report=technical_report,
+            macro_report=macro_report,
+            sector_report=sector_report,
+            risk_report=risk_report,
+            correlation_report=correlation_report,
+            synthesis_raw_response=synthesis_raw_response,
+            synthesis_summary=synthesis_summary,
+            symbols_analyzed=list(analyst_reports.keys()),
+            market_summary_snapshot=market_summary_snapshot,
+            sector_performance_snapshot=sector_performance_snapshot,
+            economic_indicators_snapshot=economic_indicators_snapshot,
+            analysts_summary=analysts_summary,
+            key_data_points=key_data_points[:20],
+            estimated_token_count=estimated_token_count,
+            analysis_duration_seconds=None,
+            successful_analysts=successful_analysts,
+            analyst_errors=None,
+        )
+
     async def _store_insights_from_heatmap(
         self,
         session: Any,
@@ -1305,6 +1477,8 @@ class AutonomousDeepEngine:
         macro_result: MacroScanResult,
         heatmap_analysis: HeatmapAnalysis,
         pre_context: dict[str, Any] | None = None,
+        analyst_reports: dict[str, dict[str, Any]] | None = None,
+        synthesis_raw_response: str | None = None,
     ) -> list[DeepInsight]:
         """Store insights in database with heatmap metadata.
 
@@ -1314,6 +1488,8 @@ class AutonomousDeepEngine:
             macro_result: Macro scan results for context.
             heatmap_analysis: Heatmap analysis for context.
             pre_context: Pre-built market context with rich_technical data.
+            analyst_reports: Per-symbol analyst reports for research context.
+            synthesis_raw_response: Raw LLM synthesis response text.
 
         Returns:
             List of created DeepInsight objects.
@@ -1373,6 +1549,26 @@ class AutonomousDeepEngine:
                 )
 
                 session.add(insight)
+
+                # Create and attach research context
+                if analyst_reports:
+                    try:
+                        research_ctx = self._create_research_context(
+                            insight=insight,
+                            analyst_reports=analyst_reports,
+                            macro_result=macro_result,
+                            synthesis_raw_response=synthesis_raw_response,
+                            total_insights_count=len(insights_data),
+                            pre_context=pre_context,
+                            heatmap_analysis=heatmap_analysis,
+                        )
+                        session.add(research_ctx)
+                    except Exception as rc_err:
+                        logger.warning(
+                            f"[AUTO] Research context creation failed for "
+                            f"{data.get('primary_symbol')}: {rc_err}"
+                        )
+
                 stored.append(insight)
 
             except Exception as e:
@@ -1678,7 +1874,7 @@ class AutonomousDeepEngine:
             await self._update_task_progress(task_id, "synthesis", 85, "Synthesizing insights...")
             if self._run_metrics:
                 self._run_metrics.start_phase("synthesis")
-            insights_data = await self._run_synthesis(
+            insights_data, synthesis_raw_response = await self._run_synthesis(
                 analyst_reports=analyst_reports,
                 macro_context=macro_result,
                 sector_context=sector_result,
@@ -1692,7 +1888,9 @@ class AutonomousDeepEngine:
 
             async with async_session_factory() as session:
                 saved_insights = await self._store_insights(
-                    session, insights_data, macro_result, sector_result, candidates
+                    session, insights_data, macro_result, sector_result, candidates,
+                    analyst_reports=analyst_reports,
+                    synthesis_raw_response=synthesis_raw_response,
                 )
                 result.insights = saved_insights
 
@@ -2174,7 +2372,7 @@ class AutonomousDeepEngine:
         candidates: OpportunityList,
         max_insights: int,
         portfolio_holdings: dict[str, dict[str, float]] | None = None,
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], str]:
         """Run Phase 5: Synthesis Lead (legacy pipeline).
 
         Args:
@@ -2186,16 +2384,17 @@ class AutonomousDeepEngine:
             portfolio_holdings: Optional dict of user portfolio holdings.
 
         Returns:
-            List of insight dictionaries.
+            Tuple of (list of insight dictionaries, raw LLM response).
         """
         # Build enhanced synthesis context
         async with async_session_factory() as session:
             memory_service = InstitutionalMemoryService(session)
 
             # Get patterns and track record
+            current_conditions = self._extract_conditions_from_analyst_reports(analyst_reports)
             patterns = await memory_service.get_relevant_patterns(
                 symbols=[c.symbol for c in candidates.candidates[:10]],
-                current_conditions={},
+                current_conditions=current_conditions,
             )
             track_record = await memory_service.get_insight_track_record()
 
@@ -2232,7 +2431,38 @@ class AutonomousDeepEngine:
         # Query LLM
         response = await self._query_llm(enhanced_prompt, full_context, "synthesis", "synthesis")
 
-        return parse_synthesis_response(response)
+        try:
+            insights = parse_synthesis_response(response)
+        except Exception as parse_err:
+            logger.error(f"[AUTO] Failed to parse synthesis response: {parse_err} | preview: {response[:500]}")
+            insights = []
+
+        # Adjust confidence based on historical track record
+        try:
+            async with async_session_factory() as adj_session:
+                memory_service_adj = InstitutionalMemoryService(adj_session)
+                adjuster = ConfidenceAdjuster(adj_session, memory_service_adj)
+                for insight_dict in insights:
+                    try:
+                        result = await adjuster.adjust_confidence(
+                            base_confidence=float(insight_dict.get("confidence", 0.5)),
+                            insight_type=insight_dict.get("insight_type", "opportunity"),
+                            action_type=insight_dict.get("action", "HOLD"),
+                            symbols=[insight_dict["primary_symbol"]] if insight_dict.get("primary_symbol") else None,
+                        )
+                        old_conf = insight_dict.get("confidence", 0.5)
+                        insight_dict["confidence"] = result["adjusted_confidence"]
+                        if result["adjusted_confidence"] != old_conf:
+                            logger.info(
+                                f"[AUTO] Confidence adjusted for {insight_dict.get('primary_symbol')}: "
+                                f"{old_conf:.2f} -> {result['adjusted_confidence']:.2f}"
+                            )
+                    except Exception as adj_err:
+                        logger.warning(f"[AUTO] Confidence adjustment failed: {adj_err}")
+        except Exception as e:
+            logger.warning(f"[AUTO] Confidence adjustment phase failed: {e}")
+
+        return insights, response
 
     def _build_autonomous_synthesis_context(
         self,
@@ -2296,6 +2526,59 @@ class AutonomousDeepEngine:
 
         return "\n".join(lines)
 
+    def _extract_conditions_from_analyst_reports(
+        self,
+        analyst_reports: dict[str, dict[str, Any]],
+    ) -> dict[str, Any]:
+        """Extract current market conditions from analyst reports for pattern matching.
+
+        Pulls measurable indicators like RSI, VIX, and volume data from
+        the per-symbol analyst reports to enable pattern matching.
+
+        Args:
+            analyst_reports: Dictionary mapping symbols to their analyst report dicts.
+
+        Returns:
+            Dictionary of current conditions (rsi, vix, volume_surge_pct, etc.).
+        """
+        conditions: dict[str, Any] = {}
+
+        for symbol, reports in analyst_reports.items():
+            if not isinstance(reports, dict):
+                continue
+
+            # Extract RSI from technical report
+            tech = reports.get("technical", {})
+            if isinstance(tech, dict) and "error" not in tech:
+                findings = tech.get("findings", [])
+                for finding in findings if isinstance(findings, list) else []:
+                    if isinstance(finding, dict):
+                        rsi = finding.get("rsi")
+                        if rsi is not None and "rsi" not in conditions:
+                            conditions["rsi"] = rsi
+
+            # Extract VIX from risk report
+            risk = reports.get("risk", {})
+            if isinstance(risk, dict) and "error" not in risk:
+                vol_regime = risk.get("volatility_regime", {})
+                if isinstance(vol_regime, dict):
+                    vix = vol_regime.get("vix") or vol_regime.get("current_vix")
+                    if vix is not None and "vix" not in conditions:
+                        conditions["vix"] = vix
+
+            # Extract volume data from technical report
+            if isinstance(tech, dict) and "error" not in tech:
+                for finding in tech.get("findings", []) if isinstance(tech.get("findings"), list) else []:
+                    if isinstance(finding, dict):
+                        vol = finding.get("volume_surge_pct") or finding.get("volume_ratio")
+                        if vol is not None and "volume_surge_pct" not in conditions:
+                            conditions["volume_surge_pct"] = vol
+
+        if conditions:
+            logger.info(f"[AUTO] Extracted conditions from analyst reports: {conditions}")
+
+        return conditions
+
     def _flatten_analyst_reports(
         self,
         analyst_reports: dict[str, dict[str, Any]],
@@ -2352,6 +2635,8 @@ class AutonomousDeepEngine:
         macro_result: MacroScanResult,
         sector_result: SectorRotationResult,
         candidates: OpportunityList,
+        analyst_reports: dict[str, dict[str, Any]] | None = None,
+        synthesis_raw_response: str | None = None,
     ) -> list[DeepInsight]:
         """Store insights in database (legacy pipeline).
 
@@ -2361,6 +2646,8 @@ class AutonomousDeepEngine:
             macro_result: Macro scan results for context.
             sector_result: Sector rotation results for context.
             candidates: Opportunity candidates for context.
+            analyst_reports: Per-symbol analyst reports for research context.
+            synthesis_raw_response: Raw LLM synthesis response text.
 
         Returns:
             List of created DeepInsight objects.
@@ -2413,6 +2700,25 @@ class AutonomousDeepEngine:
                 )
 
                 session.add(insight)
+
+                # Create and attach research context
+                if analyst_reports:
+                    try:
+                        research_ctx = self._create_research_context(
+                            insight=insight,
+                            analyst_reports=analyst_reports,
+                            macro_result=macro_result,
+                            synthesis_raw_response=synthesis_raw_response,
+                            total_insights_count=len(insights_data),
+                            sector_result=sector_result,
+                        )
+                        session.add(research_ctx)
+                    except Exception as rc_err:
+                        logger.warning(
+                            f"[AUTO] Research context creation failed for "
+                            f"{data.get('primary_symbol')}: {rc_err}"
+                        )
+
                 stored.append(insight)
 
             except Exception as e:

--- a/backend/analysis/deep_engine.py
+++ b/backend/analysis/deep_engine.py
@@ -48,15 +48,18 @@ from analysis.agents.risk_analyst import (
     parse_risk_response,
 )
 from analysis.agents.synthesis_lead import (
-    SYNTHESIS_LEAD_PROMPT,
     format_synthesis_context,
     parse_synthesis_response,
+    format_synthesis_prompt_with_context,
+    build_pattern_context,
+    build_track_record_context,
 )
 from analysis.context_builder import market_context_builder
 from analysis.statistical_calculator import StatisticalFeatureCalculator
 from analysis.memory_service import InstitutionalMemoryService
 from analysis.outcome_tracker import InsightOutcomeTracker
 from analysis.pattern_extractor import PatternExtractor
+from analysis.confidence_adjuster import ConfidenceAdjuster
 
 logger = logging.getLogger(__name__)
 
@@ -412,8 +415,27 @@ class DeepAnalysisEngine:
         synthesis_context = format_synthesis_context(analyst_reports)
         logger.info(f"[DEEP] Synthesis context length: {len(synthesis_context)} chars")
 
-        # Query LLM
-        response_text = await self._query_llm(SYNTHESIS_LEAD_PROMPT, synthesis_context, "synthesis")
+        # Build enhanced synthesis prompt with institutional memory
+        try:
+            async with async_session_factory() as mem_session:
+                memory_service = InstitutionalMemoryService(mem_session)
+                patterns = await memory_service.get_relevant_patterns(
+                    symbols=[k for k in analyst_reports.keys() if k not in ("error",)][:10],
+                    current_conditions=self._extract_conditions_from_reports(analyst_reports),
+                )
+                track_record = await memory_service.get_insight_track_record()
+
+            pattern_context_str = build_pattern_context(patterns)
+            track_record_str = build_track_record_context(track_record)
+            enhanced_prompt = format_synthesis_prompt_with_context(
+                pattern_context=pattern_context_str,
+                track_record_context=track_record_str,
+            )
+        except Exception as e:
+            logger.warning(f"[DEEP] Failed to build enhanced synthesis prompt: {e}")
+            enhanced_prompt = format_synthesis_prompt_with_context()
+
+        response_text = await self._query_llm(enhanced_prompt, synthesis_context, "synthesis")
         logger.info(f"[DEEP] Synthesis response length: {len(response_text)} chars")
         logger.info(f"[DEEP] Synthesis response preview: {response_text[:500]}")
 
@@ -491,8 +513,31 @@ class DeepAnalysisEngine:
                     continue
 
             if stored:
-                await session.commit()
+                await session.flush()
                 logger.info(f"Successfully stored {len(stored)} DeepInsight records")
+
+                # Adjust confidence based on historical track record
+                try:
+                    memory_service = InstitutionalMemoryService(session)
+                    adjuster = ConfidenceAdjuster(session, memory_service)
+                    for insight in stored:
+                        try:
+                            result = await adjuster.adjust_confidence(
+                                base_confidence=insight.confidence,
+                                insight_type=insight.insight_type or "opportunity",
+                                action_type=insight.action or "HOLD",
+                                symbols=[insight.primary_symbol] if insight.primary_symbol else None,
+                            )
+                            if result["adjusted_confidence"] != insight.confidence:
+                                insight.confidence = result["adjusted_confidence"]
+                                logger.info(
+                                    f"[DEEP] Confidence adjusted for {insight.primary_symbol}: "
+                                    f"{result['base_confidence']:.2f} -> {result['adjusted_confidence']:.2f}"
+                                )
+                        except Exception as adj_err:
+                            logger.warning(f"[DEEP] Confidence adjustment failed for {insight.primary_symbol}: {adj_err}")
+                except Exception as e:
+                    logger.warning(f"[DEEP] Confidence adjustment phase failed: {e}")
 
                 # Extract patterns from each stored insight
                 try:
@@ -718,6 +763,51 @@ class DeepAnalysisEngine:
                         data_points.append(f"RSI:{symbol}={rsi:.1f}")
 
         return data_points[:20]  # Limit to 20 data points
+
+    def _extract_conditions_from_reports(
+        self,
+        analyst_reports: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Extract current market conditions from analyst reports for pattern matching.
+
+        Args:
+            analyst_reports: Dictionary mapping analyst names to their reports.
+
+        Returns:
+            Dictionary of current conditions (rsi, vix, volume_surge, etc.).
+        """
+        conditions: dict[str, Any] = {}
+
+        # Extract RSI from technical report
+        tech_report = analyst_reports.get("technical", {})
+        if tech_report and "error" not in tech_report:
+            findings = tech_report.get("findings", [])
+            for finding in findings:
+                if isinstance(finding, dict):
+                    rsi = finding.get("rsi")
+                    if rsi is not None:
+                        conditions["rsi"] = rsi
+                        break
+
+        # Extract VIX from risk report
+        risk_report = analyst_reports.get("risk", {})
+        if risk_report and "error" not in risk_report:
+            vol_regime = risk_report.get("volatility_regime", {})
+            if isinstance(vol_regime, dict):
+                vix = vol_regime.get("vix") or vol_regime.get("current_vix")
+                if vix is not None:
+                    conditions["vix"] = vix
+
+        # Extract volume surge from technical report
+        if tech_report and "error" not in tech_report:
+            for finding in tech_report.get("findings", []):
+                if isinstance(finding, dict):
+                    volume = finding.get("volume_surge_pct") or finding.get("volume_ratio")
+                    if volume is not None:
+                        conditions["volume_surge_pct"] = volume
+                        break
+
+        return conditions
 
     @property
     def last_analysis_time(self) -> datetime | None:

--- a/backend/analysis/outcome_tracker.py
+++ b/backend/analysis/outcome_tracker.py
@@ -8,7 +8,6 @@ the tracking period ends.
 import logging
 from datetime import date, timedelta
 from typing import Any
-from uuid import UUID
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -274,21 +273,13 @@ class InsightOutcomeTracker:
 
             # Check if research context has pattern references
             research_context = insight.research_context
-            if not hasattr(research_context, "identified_patterns"):
+
+            # Read pattern IDs from the new identified_pattern_ids field
+            pattern_ids = research_context.identified_pattern_ids
+            if not pattern_ids:
                 continue
 
-            pattern_refs = getattr(research_context, "identified_patterns", [])
-            if not pattern_refs:
-                continue
-
-            for pattern_ref in pattern_refs:
-                # Extract pattern ID from reference (could be UUID or dict)
-                pattern_id = None
-                if isinstance(pattern_ref, dict):
-                    pattern_id = pattern_ref.get("pattern_id")
-                elif isinstance(pattern_ref, (str, UUID)):
-                    pattern_id = pattern_ref
-
+            for pattern_id in pattern_ids:
                 if not pattern_id:
                     continue
 

--- a/backend/analysis/pattern_extractor.py
+++ b/backend/analysis/pattern_extractor.py
@@ -24,6 +24,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from llm.client_pool import pool_query_llm
 
+from models.insight_research_context import InsightResearchContext
 from models.knowledge_pattern import KnowledgePattern, PatternType
 
 
@@ -291,6 +292,29 @@ class PatternExtractor:
             )
 
             logger.info(f"Created pattern from insight: {pattern.pattern_name}")
+
+            # Link pattern ID back to insight's research context
+            try:
+                if source_insight_id and pattern.id:
+                    # Find research context for this insight
+                    rc_query = select(InsightResearchContext).where(
+                        InsightResearchContext.deep_insight_id == source_insight_id
+                    )
+                    rc_result = await self.db.execute(rc_query)
+                    research_context = rc_result.scalar_one_or_none()
+
+                    if research_context:
+                        existing_ids = list(research_context.identified_pattern_ids or [])
+                        if pattern.id not in existing_ids:
+                            existing_ids.append(pattern.id)
+                            research_context.identified_pattern_ids = existing_ids
+                            await self.db.flush()
+                            logger.info(
+                                f"Linked pattern {pattern.id} to insight {source_insight_id} research context"
+                            )
+            except Exception as link_err:
+                logger.warning(f"Failed to link pattern to research context: {link_err}")
+
             return pattern
 
         except Exception as e:

--- a/backend/models/insight_research_context.py
+++ b/backend/models/insight_research_context.py
@@ -209,6 +209,13 @@ class InsightResearchContext(TimestampMixin, Base):
         default=None,
     )
 
+    # IDs of KnowledgePattern records extracted from this insight's analysis
+    identified_pattern_ids: Mapped[list[int] | None] = mapped_column(
+        JSON,
+        nullable=True,
+        default=list,
+    )
+
     # =========================================================================
     # INDEXES
     # =========================================================================
@@ -269,6 +276,7 @@ class InsightResearchContext(TimestampMixin, Base):
             "analysis_duration_seconds": self.analysis_duration_seconds,
             "successful_analysts": self.successful_analysts,
             "analyst_errors": self.analyst_errors,
+            "identified_pattern_ids": self.identified_pattern_ids,
             # Timestamps
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
@@ -284,4 +292,5 @@ class InsightResearchContext(TimestampMixin, Base):
             "synthesis_summary": self.synthesis_summary,
             "estimated_token_count": self.estimated_token_count,
             "successful_analysts": self.successful_analysts,
+            "identified_pattern_ids": self.identified_pattern_ids,
         }


### PR DESCRIPTION
### **User description**
## Summary

Closes the broken learning feedback loops in the analysis pipeline. Five fixes ensure that pattern extraction, outcome tracking, and confidence adjustment actually work end-to-end:

- **Wire ConfidenceAdjuster into both engines**: `deep_engine.py` and `autonomous_engine.py` now instantiate `ConfidenceAdjuster` and call it post-synthesis to adjust insight confidence scores using historical track record data.
- **Fix deep engine synthesis prompt**: Replace raw prompt with unresolved `{pattern_context}` placeholders — now calls `format_synthesis_prompt_with_context()` with real extracted patterns and track record, matching what autonomous engine already does.
- **Pattern-outcome linking chain**: Add `identified_pattern_ids` column to `InsightResearchContext` model. `PatternExtractor` now writes matched pattern IDs back to the research context. `OutcomeTracker` reads from this new field to link outcomes to the patterns that predicted them.
- **Fix empty `current_conditions`**: Both engines now extract RSI, VIX, and volume signals from analyst reports and pass them as `current_conditions` to the pattern matching pipeline, so pattern confidence adjustments have real market data.
- **Add InsightResearchContext to autonomous engine**: Autonomous engine storage methods (`_store_deep_insight`, `_store_deep_insights_batch`) now create `InsightResearchContext` records, closing the feedback loop that was previously only wired for the deep engine.

## Files changed

- `backend/models/insight_research_context.py` — add `identified_pattern_ids` column
- `backend/analysis/pattern_extractor.py` — link extracted pattern IDs back to research context
- `backend/analysis/outcome_tracker.py` — read pattern IDs from research context for outcome linking
- `backend/analysis/deep_engine.py` — wire ConfidenceAdjuster, fix synthesis prompt, extract conditions
- `backend/analysis/autonomous_engine.py` — wire ConfidenceAdjuster, extract conditions, create InsightResearchContext records

## Test plan

- [ ] Run `uv run pytest` to verify no regressions
- [ ] Trigger a deep analysis and verify confidence scores are adjusted post-synthesis
- [ ] Trigger an autonomous analysis and verify InsightResearchContext records are created
- [ ] Verify pattern IDs appear in research context after pattern extraction
- [ ] Check that outcome tracking correctly links back to identified patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Wire ConfidenceAdjuster into both analysis engines for post-synthesis confidence score adjustment

- Fix deep engine synthesis prompt to use institutional memory patterns and track record

- Add identified_pattern_ids column to InsightResearchContext for pattern-outcome linking

- Extract RSI, VIX, and volume signals from analyst reports as current_conditions

- Create InsightResearchContext records in autonomous engine storage methods


___

### Diagram Walkthrough


```mermaid
flowchart LR
  AR["Analyst Reports"] -->|extract conditions| EC["Current Conditions<br/>RSI/VIX/Volume"]
  EC -->|pattern matching| PE["Pattern Extractor"]
  PE -->|identified_pattern_ids| IRC["InsightResearchContext"]
  SYN["Synthesis"] -->|base confidence| CA["ConfidenceAdjuster"]
  CA -->|track record| AC["Adjusted Confidence"]
  AC -->|update insight| INS["DeepInsight"]
  INS -->|outcome tracking| OT["OutcomeTracker"]
  OT -->|pattern success| KP["KnowledgePattern"]
  IRC -->|pattern IDs| OT
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>insight_research_context.py</strong><dd><code>Add identified_pattern_ids column for pattern linking</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/models/insight_research_context.py

<ul><li>Add <code>identified_pattern_ids</code> JSON column to store list of extracted <br>pattern IDs<br> <li> Include new field in <code>to_dict()</code> and <code>to_summary_dict()</code> serialization <br>methods</ul>


</details>


  </td>
  <td><a href="https://github.com/barkain/teletraan/pull/11/files#diff-613a2468a399f4460e7f3955cd72d8a2ff2055b6d1fb698fe86fe86e058e1459">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>pattern_extractor.py</strong><dd><code>Link pattern IDs to research context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/analysis/pattern_extractor.py

<ul><li>Link extracted pattern IDs back to insight's InsightResearchContext <br>after pattern creation<br> <li> Query research context by insight ID and append pattern ID to <br>identified_pattern_ids list<br> <li> Add error handling for pattern linking failures</ul>


</details>


  </td>
  <td><a href="https://github.com/barkain/teletraan/pull/11/files#diff-f05502cc8f481b26da8aceaf5824549ca6dd5d0de484011b54316dd3c919e20a">+24/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>outcome_tracker.py</strong><dd><code>Read pattern IDs from research context field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/analysis/outcome_tracker.py

<ul><li>Simplify pattern ID extraction to read directly from <br><code>identified_pattern_ids</code> field<br> <li> Remove complex pattern reference parsing logic that handled dicts and <br>UUIDs<br> <li> Iterate directly over pattern IDs list for outcome tracking</ul>


</details>


  </td>
  <td><a href="https://github.com/barkain/teletraan/pull/11/files#diff-a13f1a2a61c20587f789bd03d31ab8cc7fd4ab034cc880aa14ede9c2eb2a3881">+4/-13</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>deep_engine.py</strong><dd><code>Wire ConfidenceAdjuster and fix synthesis prompt</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/analysis/deep_engine.py

<ul><li>Import and instantiate ConfidenceAdjuster to adjust insight confidence <br>post-synthesis<br> <li> Replace raw SYNTHESIS_LEAD_PROMPT with <br>format_synthesis_prompt_with_context() call<br> <li> Build pattern context and track record from institutional memory <br>before synthesis<br> <li> Add <code>_extract_conditions_from_reports()</code> method to extract RSI, VIX, <br>volume from analyst reports<br> <li> Pass extracted conditions to pattern matching instead of empty dict</ul>


</details>


  </td>
  <td><a href="https://github.com/barkain/teletraan/pull/11/files#diff-4cda34fff46e723f47dfc7d261d8649c31dd28f4f63d44e70ecd3b17ca0830a4">+94/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>autonomous_engine.py</strong><dd><code>Wire ConfidenceAdjuster and InsightResearchContext creation</code></dd></summary>
<hr>

backend/analysis/autonomous_engine.py

<ul><li>Import InsightResearchContext and ConfidenceAdjuster for feedback loop <br>closure<br> <li> Modify <code>_run_synthesis_with_heatmap()</code> to return tuple of insights and <br>raw response<br> <li> Modify <code>_run_synthesis()</code> legacy pipeline to return tuple of insights <br>and raw response<br> <li> Add ConfidenceAdjuster calls in both synthesis methods to adjust <br>confidence scores<br> <li> Add <code>_extract_conditions_from_analyst_reports()</code> method to extract <br>market signals<br> <li> Add <code>_create_research_context()</code> method to build InsightResearchContext <br>for autonomous insights<br> <li> Update <code>_store_insights_from_heatmap()</code> and <code>_store_insights()</code> to create <br>and attach research context records<br> <li> Pass analyst_reports and synthesis_raw_response through storage <br>pipeline</ul>


</details>


  </td>
  <td><a href="https://github.com/barkain/teletraan/pull/11/files#diff-0b23e7ad3480acf213da4f0017e4269aac9d627dd08417ee38d358f7462964e3">+309/-11</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

