### PR TITLE
Fix auth and chat issues

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -1,13 +1,37 @@
 """Common dependencies for API routes."""
 
 from collections.abc import AsyncGenerator
-from typing import Annotated
+from typing import Annotated, Optional
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException, Security, status
+from fastapi.security import APIKeyHeader
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config import Settings, get_settings
 from database import get_session
+
+_api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
+
+
+async def verify_api_key(
+    api_key: Optional[str] = Security(_api_key_header),
+    settings: Settings = Depends(get_settings),
+) -> None:
+    """Verify the X-API-Key header if TELETRAAN_API_KEY is configured.
+
+    When TELETRAAN_API_KEY is not set in the environment the API is open
+    (suitable for local dev). When set, every request must include a matching
+    X-API-Key header or it will be rejected with HTTP 401.
+    """
+    configured_key = settings.TELETRAAN_API_KEY
+    if not configured_key:
+        return  # Open access — no key configured
+    if api_key != configured_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing API key",
+            headers={"WWW-Authenticate": "ApiKey"},
+        )
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
@@ -19,3 +43,4 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
 # Type aliases for dependency injection
 DbSession = Annotated[AsyncSession, Depends(get_db)]
 AppSettings = Annotated[Settings, Depends(get_settings)]
+ApiKeyAuth = Annotated[None, Depends(verify_api_key)]

--- a/backend/api/routes/__init__.py
+++ b/backend/api/routes/__init__.py
@@ -1,7 +1,8 @@
 """API routes package - Combines all route modules."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from api.deps import verify_api_key
 from api.routes.analysis import router as analysis_router
 from api.routes.chat import router as chat_router
 from api.routes.data import router as data_router
@@ -23,29 +24,33 @@ from api.routes.statistical_features import router as statistical_features_route
 from api.routes.stocks import router as stocks_router
 from api.routes.thematic_insights import router as thematic_insights_router
 
+_auth = [Depends(verify_api_key)]
+
 # Combined router for all routes
 router = APIRouter()
 
-# Include route modules
+# Health check is always public (needed for uptime monitors and readiness probes)
 router.include_router(health_router, tags=["health"])
-router.include_router(analysis_router)
-router.include_router(chat_router)
-router.include_router(data_router, tags=["data"])
-router.include_router(deep_insights_router, prefix="/deep-insights", tags=["deep-insights"])
-router.include_router(insight_conversations_router, tags=["insight-conversations"])
-router.include_router(insight_modifications_router, tags=["insight-modifications"])
-router.include_router(insights_router)
-router.include_router(search_router)
-router.include_router(settings_router, tags=["settings"])
-router.include_router(statistical_features_router, tags=["features"])
-router.include_router(stocks_router, tags=["stocks"])
-router.include_router(outcomes_router, tags=["outcomes"])
-router.include_router(knowledge_router, prefix="/knowledge", tags=["knowledge"])
-router.include_router(portfolio_router, prefix="/portfolio", tags=["portfolio"])
-router.include_router(reports_router, prefix="/reports", tags=["reports"])
-router.include_router(research_router, tags=["research"])
-router.include_router(runs_router, prefix="/runs", tags=["runs"])
-router.include_router(export_router)
-router.include_router(thematic_insights_router, prefix="/thematic-insights", tags=["thematic-insights"])
+
+# All other routes require API key auth when TELETRAAN_API_KEY is set
+router.include_router(analysis_router, dependencies=_auth)
+router.include_router(chat_router, dependencies=_auth)
+router.include_router(data_router, tags=["data"], dependencies=_auth)
+router.include_router(deep_insights_router, prefix="/deep-insights", tags=["deep-insights"], dependencies=_auth)
+router.include_router(insight_conversations_router, tags=["insight-conversations"], dependencies=_auth)
+router.include_router(insight_modifications_router, tags=["insight-modifications"], dependencies=_auth)
+router.include_router(insights_router, dependencies=_auth)
+router.include_router(search_router, dependencies=_auth)
+router.include_router(settings_router, tags=["settings"], dependencies=_auth)
+router.include_router(statistical_features_router, tags=["features"], dependencies=_auth)
+router.include_router(stocks_router, tags=["stocks"], dependencies=_auth)
+router.include_router(outcomes_router, tags=["outcomes"], dependencies=_auth)
+router.include_router(knowledge_router, prefix="/knowledge", tags=["knowledge"], dependencies=_auth)
+router.include_router(portfolio_router, prefix="/portfolio", tags=["portfolio"], dependencies=_auth)
+router.include_router(reports_router, prefix="/reports", tags=["reports"], dependencies=_auth)
+router.include_router(research_router, tags=["research"], dependencies=_auth)
+router.include_router(runs_router, prefix="/runs", tags=["runs"], dependencies=_auth)
+router.include_router(export_router, dependencies=_auth)
+router.include_router(thematic_insights_router, prefix="/thematic-insights", tags=["thematic-insights"], dependencies=_auth)
 
 __all__ = ["router"]

--- a/backend/api/routes/chat.py
+++ b/backend/api/routes/chat.py
@@ -3,10 +3,12 @@
 import json
 import logging
 import uuid
+from typing import Optional
 
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+from fastapi import APIRouter, Query, WebSocket, WebSocketDisconnect, WebSocketException, status
 
-from llm.market_agent import get_market_agent
+from config import get_settings
+from llm.market_agent import MarketAnalysisAgent
 
 logger = logging.getLogger(__name__)
 
@@ -65,9 +67,32 @@ class ConnectionManager:
 manager = ConnectionManager()
 
 
+def _check_ws_api_key(api_key: Optional[str]) -> None:
+    """Verify the API key for a WebSocket connection.
+
+    WebSocket upgrade requests cannot carry custom headers in browsers, so the
+    API key is accepted as an ``?api_key=`` query parameter instead.
+    """
+    settings = get_settings()
+    configured_key = settings.TELETRAAN_API_KEY
+    if not configured_key:
+        return  # Open access — no key configured
+    if api_key != configured_key:
+        raise WebSocketException(code=status.WS_1008_POLICY_VIOLATION)
+
+
 @router.websocket("/chat")
-async def chat_websocket(websocket: WebSocket) -> None:
+async def chat_websocket(
+    websocket: WebSocket,
+    api_key: Optional[str] = Query(None, alias="api_key"),
+) -> None:
     """WebSocket endpoint for streaming LLM chat responses.
+
+    Each connection gets its own isolated agent instance with independent
+    conversation history — sessions never bleed into one another.
+
+    Authentication: pass ``?api_key=<key>`` in the WebSocket URL when
+    ``TELETRAAN_API_KEY`` is configured.
 
     Message Protocol:
     - Client sends: {"id": "msg-id", "message": "user question"}
@@ -78,12 +103,13 @@ async def chat_websocket(websocket: WebSocket) -> None:
     - Server sends (done): {"type": "done"}
     - Server sends (error): {"type": "error", "error": "error message"}
     """
-    client_id = str(uuid.uuid4())
+    _check_ws_api_key(api_key)
 
+    client_id = str(uuid.uuid4())
     await manager.connect(websocket, client_id)
 
-    # Get or create agent instance for this client
-    agent = get_market_agent()
+    # Each connection gets its own agent — no shared conversation state
+    agent = MarketAnalysisAgent()
 
     try:
         while True:
@@ -168,11 +194,9 @@ async def chat_websocket(websocket: WebSocket) -> None:
 
 @router.post("/chat/clear")
 async def clear_chat() -> dict:
-    """Clear chat history for all sessions.
+    """Clear chat history endpoint (no-op — history is now per-session).
 
     Returns:
-        Status message indicating history was cleared.
+        Status message.
     """
-    agent = get_market_agent()
-    agent.clear_history()
-    return {"status": "cleared", "message": "Chat history has been cleared"}
+    return {"status": "ok", "message": "Chat history is per-session; no global state to clear"}

--- a/backend/config.py
+++ b/backend/config.py
@@ -51,6 +51,11 @@ class Settings(BaseSettings):
     FRED_API_KEY: Optional[str] = None
     FINNHUB_API_KEY: Optional[str] = None
 
+    # Application auth
+    # Set TELETRAAN_API_KEY to require X-API-Key header on all API routes.
+    # If unset, the API is open (suitable for local dev only).
+    TELETRAAN_API_KEY: Optional[str] = None
+
     # Application
     DEBUG: bool = False
     API_V1_PREFIX: str = "/api/v1"

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,6 +2,12 @@
 const rawUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 const API_URL = rawUrl.replace(/\/api\/v1\/?$/, '');
 
+// Optional API key injected into every request when NEXT_PUBLIC_API_KEY is set
+const _API_KEY = process.env.NEXT_PUBLIC_API_KEY || '';
+function _authHeader(): Record<string, string> {
+  return _API_KEY ? { 'X-API-Key': _API_KEY } : {};
+}
+
 export class ApiError extends Error {
   constructor(public status: number, message: string) {
     super(message);
@@ -36,6 +42,7 @@ export async function fetchApi<T>(
     ...fetchOptions,
     headers: {
       'Content-Type': 'application/json',
+      ..._authHeader(),
       ...fetchOptions?.headers,
     },
   });

--- a/frontend/lib/hooks/use-chat.ts
+++ b/frontend/lib/hooks/use-chat.ts
@@ -4,8 +4,17 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 import type { Message, ToolCall, ChatState, SendMessageOptions } from '@/types/chat';
 
 // WebSocket URL - can be configured via environment variable
-const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8000/api/v1/chat';
+const _WS_BASE = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8000/api/v1/chat';
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api/v1';
+
+// Optional API key — appended as ?api_key=<key> to the WebSocket URL and sent
+// as X-API-Key header on REST requests when NEXT_PUBLIC_API_KEY is set.
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY || '';
+const WS_URL = API_KEY ? `${_WS_BASE}?api_key=${encodeURIComponent(API_KEY)}` : _WS_BASE;
+
+function apiHeaders(): HeadersInit {
+  return API_KEY ? { 'X-API-Key': API_KEY } : {};
+}
 
 // Reconnection settings
 const RECONNECT_INTERVAL = 3000;
@@ -311,7 +320,7 @@ export function useChat() {
 
     // Also clear on server
     try {
-      await fetch(`${API_URL}/chat/clear`, { method: 'POST' });
+      await fetch(`${API_URL}/chat/clear`, { method: 'POST', headers: apiHeaders() });
     } catch (error) {
       console.error('Failed to clear server chat history:', error);
     }


### PR DESCRIPTION
## Summary

### Auth fix — API key protection for all routes

Teletraan had zero authentication on any API endpoint. Anyone on the network could trigger analysis runs, read portfolio data, or modify settings.

- `config.py`: new `TELETRAAN_API_KEY` setting. When unset (default) the API stays open — no breaking change for local dev.
- `api/deps.py`: `verify_api_key` FastAPI dependency — checks `X-API-Key` header, raises HTTP 401 if key is set and wrong/missing.
- `api/routes/__init__.py`: applies `verify_api_key` to every router **except** `/health` (needed for uptime probes without auth).
- `frontend/lib/api.ts`: injects `X-API-Key` header on all REST calls when `NEXT_PUBLIC_API_KEY` is set.
- `frontend/lib/hooks/use-chat.ts`: appends `?api_key=` to WebSocket URL and header to `/chat/clear`.

To enable: set `TELETRAAN_API_KEY=<secret>` in `backend/.env` and `NEXT_PUBLIC_API_KEY=<secret>` in `frontend/.env.local`.

### Chat fix — per-session conversation history

All WebSocket connections shared a single `MarketAnalysisAgent` singleton (`_agent_instance`), so every user saw everyone else's conversation history. Opening a second browser tab would bleed context into the first.

- `api/routes/chat.py`: creates a fresh `MarketAnalysisAgent()` per WebSocket connection — fully isolated history per session.
- WebSocket auth uses `?api_key=` query param (browsers cannot send custom headers during WebSocket upgrade).
- `/chat/clear` POST endpoint updated to reflect the per-session model.

## Test plan
- [ ] Start backend without `TELETRAAN_API_KEY` set — all endpoints accessible as before
- [ ] Set `TELETRAAN_API_KEY=test123` — verify unauthenticated requests get HTTP 401, `/health` still returns 200
- [ ] Set matching `NEXT_PUBLIC_API_KEY=test123` in frontend — verify UI works normally
- [ ] Open two browser tabs, ask different questions in each — verify histories are independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)