### PR TITLE
feat: options-implied signals + sector momentum rankings

### DIFF
--- a/backend/analysis/agents/heatmap_fetcher.py
+++ b/backend/analysis/agents/heatmap_fetcher.py
@@ -608,8 +608,8 @@ def format_heatmap_for_llm(data: HeatmapData) -> str:
         if momentum_table:
             lines.append("")
             lines.append(momentum_table)
-    except Exception:
-        pass  # Non-fatal: omit if sector momentum fails
+    except Exception as exc:
+        logger.debug("sector momentum table skipped: %s", exc)  # Non-fatal: omit if unavailable
 
     return "\n".join(lines)
 

--- a/backend/analysis/agents/heatmap_fetcher.py
+++ b/backend/analysis/agents/heatmap_fetcher.py
@@ -27,6 +27,7 @@ from analysis.agents.heatmap_interfaces import (  # type: ignore[import-not-foun
     SectorHeatmapEntry,
     StockHeatmapEntry,
 )
+from analysis.sectors import get_sector_etfs
 
 logger = logging.getLogger(__name__)
 
@@ -53,20 +54,6 @@ def _set_cache(key: str, data: Any) -> None:
     _yf_cache[key] = (time.time(), data)
 
 
-# 11 GICS Sector SPDR ETFs
-SECTOR_ETFS: dict[str, str] = {
-    "XLK": "Technology",
-    "XLF": "Financials",
-    "XLE": "Energy",
-    "XLV": "Healthcare",
-    "XLI": "Industrials",
-    "XLP": "Consumer Staples",
-    "XLY": "Consumer Discretionary",
-    "XLU": "Utilities",
-    "XLC": "Communication Services",
-    "XLRE": "Real Estate",
-    "XLB": "Materials",
-}
 
 # Fallback constituent holdings when yfinance can't provide them.
 # Sourced from opportunity_hunter.SECTOR_HOLDINGS.
@@ -114,8 +101,12 @@ class SectorHeatmapFetcher:
     """
 
     def __init__(self) -> None:
-        self._sector_etfs = SECTOR_ETFS
         self._fallback_holdings = FALLBACK_HOLDINGS
+
+    @property
+    def _sector_etfs(self) -> dict[str, str]:
+        """Live sector ETF mapping — always reflects the current settings."""
+        return get_sector_etfs()
 
     # ------------------------------------------------------------------
     # Public API

--- a/backend/analysis/agents/heatmap_fetcher.py
+++ b/backend/analysis/agents/heatmap_fetcher.py
@@ -284,7 +284,7 @@ class SectorHeatmapFetcher:
             logger.debug("Batch download cache hit (%d symbols)", len(symbols))
             return cached
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         def _download() -> Any:
             try:
@@ -474,7 +474,7 @@ class SectorHeatmapFetcher:
 
         Returns market cap in billions USD. Symbols that fail are omitted.
         """
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
 
         def _get_single_cap(sym: str) -> tuple[str, float | None]:
             cached = _get_cached(f"mcap:{sym}")

--- a/backend/analysis/agents/heatmap_fetcher.py
+++ b/backend/analysis/agents/heatmap_fetcher.py
@@ -236,6 +236,7 @@ class SectorHeatmapFetcher:
                 change_1d=etf_m.get("change_1d", 0.0),
                 change_5d=etf_m.get("change_5d", 0.0),
                 change_20d=etf_m.get("change_20d", 0.0),
+                change_60d=etf_m.get("change_60d"),
                 breadth=breadth,
                 top_gainers=top_gainers,
                 top_losers=top_losers,
@@ -603,6 +604,21 @@ def format_heatmap_for_llm(data: HeatmapData) -> str:
         bar_len = int(s.breadth * 20)
         bar = "#" * bar_len + "." * (20 - bar_len)
         lines.append(f"  {s.name:25s} [{bar}] {s.breadth * 100:.0f}%")
+    lines.append("")
+
+    # --- Sector Momentum Rankings ---
+    try:
+        from analysis.sector_momentum import (  # type: ignore[import-not-found]
+            compute_sector_momentum_from_heatmap,
+            format_momentum_table,
+        )
+        momentum_data = compute_sector_momentum_from_heatmap(data.sectors)
+        momentum_table = format_momentum_table(momentum_data)
+        if momentum_table:
+            lines.append("")
+            lines.append(momentum_table)
+    except Exception:
+        pass  # Non-fatal: omit if sector momentum fails
 
     return "\n".join(lines)
 

--- a/backend/analysis/agents/heatmap_interfaces.py
+++ b/backend/analysis/agents/heatmap_interfaces.py
@@ -114,6 +114,7 @@ class SectorHeatmapEntry:
         change_1d: 1-day sector ETF change percentage
         change_5d: 5-day sector ETF change percentage
         change_20d: 20-day sector ETF change percentage
+        change_60d: 60-day sector ETF change percentage (None if unavailable)
         breadth: Fraction of stocks in sector with positive 1d change (0.0-1.0)
         top_gainers: Symbols of top 3 gainers in sector (by 1d change)
         top_losers: Symbols of top 3 losers in sector (by 1d change)
@@ -125,6 +126,7 @@ class SectorHeatmapEntry:
     change_1d: float = 0.0
     change_5d: float = 0.0
     change_20d: float = 0.0
+    change_60d: float | None = None
     breadth: float = 0.5
     top_gainers: list[str] = field(default_factory=list)
     top_losers: list[str] = field(default_factory=list)
@@ -132,7 +134,7 @@ class SectorHeatmapEntry:
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary representation."""
-        return {
+        result = {
             "name": self.name,
             "etf": self.etf,
             "change_1d": round(self.change_1d, 2),
@@ -143,16 +145,21 @@ class SectorHeatmapEntry:
             "top_losers": self.top_losers,
             "stock_count": self.stock_count,
         }
+        if self.change_60d is not None:
+            result["change_60d"] = round(self.change_60d, 2)
+        return result
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> SectorHeatmapEntry:
         """Create from dictionary."""
+        change_60d = data.get("change_60d")
         return cls(
             name=data.get("name", "Unknown"),
             etf=data.get("etf", ""),
             change_1d=float(data.get("change_1d", 0.0)),
             change_5d=float(data.get("change_5d", 0.0)),
             change_20d=float(data.get("change_20d", 0.0)),
+            change_60d=float(change_60d) if change_60d is not None else None,
             breadth=float(data.get("breadth", 0.5)),
             top_gainers=data.get("top_gainers", []),
             top_losers=data.get("top_losers", []),

--- a/backend/analysis/agents/macro_scanner.py
+++ b/backend/analysis/agents/macro_scanner.py
@@ -116,6 +116,14 @@ Return your analysis as valid JSON:
   }}
 }}
 
+## Options Sentiment Signals
+When OPTIONS SENTIMENT data is available in the market data above, incorporate these forward-looking indicators:
+- **VIX Term Structure**: Contango (VIX3M > VIX) = market calm; Backwardation = acute stress
+- **CBOE Skew Index**: Elevated (>130) = tail-risk hedging; even calm VIX + high Skew = hidden fear
+- **Put/Call Ratio**: Below 0.7 = complacency (contrarian bearish); above 1.2 = fear (contrarian bullish)
+- **VIX Percentile**: Low (<25%) = complacency; High (>75%) = fear/potential capitulation
+Options data often leads price action — use it to validate or challenge signals from other data.
+
 ## Prediction Market Signals
 When prediction market data is available, incorporate market-implied probabilities into your macro assessment:
 - Federal Reserve rate expectations (hold/cut/hike probabilities per meeting)
@@ -364,7 +372,9 @@ class MacroScanner:
     }
 
     VOLATILITY_SYMBOLS = {
-        "^VIX": "CBOE Volatility Index",
+        "^VIX": "CBOE Volatility Index (30-day)",
+        "^VIX3M": "CBOE 3-Month Volatility Index",
+        "^SKEW": "CBOE Skew Index",
     }
 
     CURRENCY_SYMBOLS = {
@@ -447,13 +457,34 @@ class MacroScanner:
         scan_start = datetime.utcnow()
         logger.info("Starting macro environment scan...")
 
-        # Step 1: Fetch macro data
-        logger.info("Fetching macro data from yfinance...")
-        macro_data = await self._fetch_macro_data()
+        # Step 1: Fetch macro data + options signals in parallel
+        logger.info("Fetching macro data and options signals from yfinance...")
+        from analysis.agents.options_signals import fetch_options_signals  # type: ignore[import-not-found]
+        macro_data_result, options_signals = await asyncio.gather(
+            self._fetch_macro_data(),
+            fetch_options_signals(self.data_adapter),
+            return_exceptions=True,
+        )
+
+        if isinstance(macro_data_result, Exception):
+            logger.error(f"Macro data fetch failed: {macro_data_result}")
+            raise macro_data_result
+        macro_data = macro_data_result
+
+        if isinstance(options_signals, Exception):
+            logger.warning(f"Options signals fetch failed: {options_signals}")
+            from analysis.agents.options_signals import OptionsSignals  # type: ignore[import-not-found]
+            options_signals = OptionsSignals()
+
         logger.info(f"Fetched data for {len(macro_data)} categories")
 
         # Step 2: Format data for LLM
         formatted_data = self._format_macro_data(macro_data)
+
+        # Step 2a: Append options sentiment block
+        options_block = options_signals.format_block()
+        if options_block:
+            formatted_data = formatted_data + "\n\n" + options_block
         logger.info(f"Formatted macro data: {len(formatted_data)} chars")
 
         # Step 2b: Append prediction/sentiment context if available

--- a/backend/analysis/agents/options_signals.py
+++ b/backend/analysis/agents/options_signals.py
@@ -1,0 +1,206 @@
+"""Options-implied market signals: VIX term structure, SKEW index, put/call ratio, IV percentile.
+
+Fetches freely available options-derived indicators from Yahoo Finance and formats
+them as structured context for macro and risk analyst agents.
+
+Signals:
+- VIX term structure: VIX vs VIX3M (contango = calm, backwardation = stressed)
+- CBOE Skew Index (^SKEW): elevated skew = tail-risk hedging even when VIX is low
+- Put/Call ratio: aggregated from SPY near-term options chain
+- VIX 52-week percentile: where current VIX sits vs the past year
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Put/call ratio reference thresholds (SPY historical averages)
+PC_RATIO_AVG = 0.9
+PC_COMPLACENT_THRESHOLD = 0.7   # below avg = too bullish / complacent
+PC_FEARFUL_THRESHOLD = 1.2       # above avg = fear / hedging
+
+
+@dataclass
+class OptionsSignals:
+    """Computed options-implied market signals."""
+
+    vix: float = 0.0
+    vix3m: float = 0.0
+    skew: float = 0.0
+    vix_percentile_52w: float = 0.0
+    term_structure: str = "unknown"       # contango | backwardation | flat
+    term_structure_spread: float = 0.0   # VIX3M - VIX (positive = contango)
+    put_call_ratio: float | None = None
+    pc_signal: str = "neutral"            # complacent | neutral | fearful
+    available: bool = False
+
+    def format_block(self) -> str:
+        """Format signals as a text block for LLM injection.
+
+        Returns:
+            Formatted string block, or empty string if signals unavailable.
+        """
+        if not self.available:
+            return ""
+
+        lines = ["=== OPTIONS SENTIMENT ==="]
+
+        # Put/call ratio
+        if self.put_call_ratio is not None:
+            delta = self.put_call_ratio - PC_RATIO_AVG
+            if delta < -0.2:
+                label = f"below avg {PC_RATIO_AVG:.1f} = complacent"
+            elif delta > 0.2:
+                label = f"above avg {PC_RATIO_AVG:.1f} = fearful/hedging"
+            else:
+                label = f"near avg {PC_RATIO_AVG:.1f} = neutral"
+            lines.append(f"- SPY Put/Call Ratio: {self.put_call_ratio:.2f} ({label})")
+
+        # VIX term structure
+        if self.vix > 0 and self.vix3m > 0:
+            mood = (
+                "calm" if self.term_structure == "contango"
+                else "stressed" if self.term_structure == "backwardation"
+                else "neutral"
+            )
+            lines.append(
+                f"- VIX Term Structure: {self.term_structure.title()} "
+                f"(VIX {self.vix:.1f}, VIX3M {self.vix3m:.1f}, "
+                f"spread {self.term_structure_spread:+.1f}) = {mood}"
+            )
+        elif self.vix > 0:
+            lines.append(f"- VIX: {self.vix:.1f}")
+
+        # CBOE Skew
+        if self.skew > 0:
+            if self.skew > 135:
+                skew_label = "elevated = significant tail-risk hedging"
+            elif self.skew > 120:
+                skew_label = "moderately elevated = some tail-risk concern"
+            elif self.skew > 110:
+                skew_label = "normal"
+            else:
+                skew_label = "low = complacency, limited tail hedging"
+            lines.append(f"- CBOE Skew: {self.skew:.0f} ({skew_label})")
+
+        # VIX 52-week percentile
+        if self.vix_percentile_52w >= 0:
+            if self.vix_percentile_52w < 25:
+                pct_label = "low = vol complacency"
+            elif self.vix_percentile_52w > 75:
+                pct_label = "high = vol fear"
+            else:
+                pct_label = "moderate"
+            lines.append(f"- VIX 52w Percentile: {self.vix_percentile_52w:.0f}% ({pct_label})")
+
+        return "\n".join(lines)
+
+
+async def fetch_options_signals(adapter: Any | None = None) -> OptionsSignals:
+    """Fetch and compute all options-implied signals.
+
+    Uses yfinance to fetch VIX history, VIX3M, CBOE Skew, and SPY options chain.
+    All I/O runs in a thread pool executor to stay non-blocking. Gracefully
+    degrades if any individual source is unavailable.
+
+    Args:
+        adapter: Optional YahooFinanceAdapter (reserved for interface consistency;
+            raw yfinance calls are used here to fetch the 1-year VIX history
+            needed for percentile calculation).
+
+    Returns:
+        OptionsSignals with all available signals populated.
+    """
+    signals = OptionsSignals()
+
+    try:
+        import yfinance as yf
+
+        loop = asyncio.get_running_loop()
+
+        async def _fetch_hist(symbol: str, period: str) -> Any:
+            ticker = yf.Ticker(symbol)
+            return await loop.run_in_executor(
+                None, lambda t=ticker, p=period: t.history(period=p)
+            )
+
+        # Parallel: VIX (1y for percentile), VIX3M (5d current), SKEW (5d current)
+        vix_hist, vix3m_hist, skew_hist = await asyncio.gather(
+            _fetch_hist("^VIX", "1y"),
+            _fetch_hist("^VIX3M", "5d"),
+            _fetch_hist("^SKEW", "5d"),
+            return_exceptions=True,
+        )
+
+        # VIX current + 52-week percentile rank
+        if (
+            not isinstance(vix_hist, Exception)
+            and vix_hist is not None
+            and not vix_hist.empty
+        ):
+            signals.vix = round(float(vix_hist["Close"].iloc[-1]), 2)
+            closes = vix_hist["Close"].dropna().tolist()
+            if len(closes) > 1:
+                below = sum(1 for v in closes[:-1] if v <= closes[-1])
+                signals.vix_percentile_52w = round((below / (len(closes) - 1)) * 100, 1)
+
+        # VIX3M current value
+        if (
+            not isinstance(vix3m_hist, Exception)
+            and vix3m_hist is not None
+            and not vix3m_hist.empty
+        ):
+            signals.vix3m = round(float(vix3m_hist["Close"].iloc[-1]), 2)
+
+        # CBOE Skew current value
+        if (
+            not isinstance(skew_hist, Exception)
+            and skew_hist is not None
+            and not skew_hist.empty
+        ):
+            signals.skew = round(float(skew_hist["Close"].iloc[-1]), 1)
+
+        # VIX term structure classification
+        if signals.vix > 0 and signals.vix3m > 0:
+            spread = signals.vix3m - signals.vix
+            signals.term_structure_spread = round(spread, 2)
+            if spread > 1.0:
+                signals.term_structure = "contango"
+            elif spread < -1.0:
+                signals.term_structure = "backwardation"
+            else:
+                signals.term_structure = "flat"
+
+        # SPY put/call ratio from near-term options chain
+        try:
+            spy = yf.Ticker("SPY")
+            expirations = await loop.run_in_executor(None, lambda t=spy: t.options)
+            if expirations:
+                chain = await loop.run_in_executor(
+                    None,
+                    lambda t=spy, e=expirations[0]: t.option_chain(e),
+                )
+                put_vol = float(chain.puts["volume"].fillna(0).sum())
+                call_vol = float(chain.calls["volume"].fillna(0).sum())
+                if call_vol > 0:
+                    signals.put_call_ratio = round(put_vol / call_vol, 2)
+                    if signals.put_call_ratio < PC_COMPLACENT_THRESHOLD:
+                        signals.pc_signal = "complacent"
+                    elif signals.put_call_ratio > PC_FEARFUL_THRESHOLD:
+                        signals.pc_signal = "fearful"
+                    else:
+                        signals.pc_signal = "neutral"
+        except Exception as e:
+            logger.debug(f"SPY put/call ratio unavailable: {e}")
+
+        signals.available = signals.vix > 0
+
+    except Exception as e:
+        logger.warning(f"Options signals fetch failed: {e}")
+
+    return signals

--- a/backend/analysis/agents/options_signals.py
+++ b/backend/analysis/agents/options_signals.py
@@ -52,10 +52,9 @@ class OptionsSignals:
 
         # Put/call ratio
         if self.put_call_ratio is not None:
-            delta = self.put_call_ratio - PC_RATIO_AVG
-            if delta < -0.2:
+            if self.put_call_ratio < PC_COMPLACENT_THRESHOLD:
                 label = f"below avg {PC_RATIO_AVG:.1f} = complacent"
-            elif delta > 0.2:
+            elif self.put_call_ratio > PC_FEARFUL_THRESHOLD:
                 label = f"above avg {PC_RATIO_AVG:.1f} = fearful/hedging"
             else:
                 label = f"near avg {PC_RATIO_AVG:.1f} = neutral"
@@ -89,7 +88,7 @@ class OptionsSignals:
             lines.append(f"- CBOE Skew: {self.skew:.0f} ({skew_label})")
 
         # VIX 52-week percentile
-        if self.vix_percentile_52w >= 0:
+        if self.vix_percentile_52w > 0:
             if self.vix_percentile_52w < 25:
                 pct_label = "low = vol complacency"
             elif self.vix_percentile_52w > 75:

--- a/backend/analysis/agents/sector_rotator.py
+++ b/backend/analysis/agents/sector_rotator.py
@@ -19,26 +19,9 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
+from analysis.sectors import get_sector_etfs, SECTOR_ETFS  # noqa: F401 (re-exported for backwards compat)
+
 logger = logging.getLogger(__name__)
-
-
-# =============================================================================
-# SECTOR ETF MAPPINGS
-# =============================================================================
-
-SECTOR_ETFS: dict[str, str] = {
-    "XLK": "Technology",
-    "XLF": "Financials",
-    "XLE": "Energy",
-    "XLV": "Healthcare",
-    "XLI": "Industrials",
-    "XLP": "Consumer Staples",
-    "XLY": "Consumer Discretionary",
-    "XLU": "Utilities",
-    "XLC": "Communication Services",
-    "XLRE": "Real Estate",
-    "XLB": "Materials",
-}
 
 # Sector characteristics for rotation analysis
 SECTOR_CHARACTERISTICS: dict[str, dict[str, Any]] = {

--- a/backend/analysis/agents/sector_rotator.py
+++ b/backend/analysis/agents/sector_rotator.py
@@ -422,6 +422,15 @@ Return JSON:
 
 IMPORTANT: The key_stocks field is REQUIRED for every top_sectors entry. Each must contain 2-3 specific tradeable symbols (individual stocks or commodity futures like GC=F, CL=F, SI=F). Never put sector ETFs in key_stocks.
 
+## Quantitative Momentum Rankings
+When SECTOR MOMENTUM RANKINGS data is provided, use it as the primary quantitative basis for your analysis:
+- **Momentum Score**: Composite relative-strength metric (1W×20% + 1M×40% + 3M×40%) — positive = outperforming SPY
+- **ACCELERATING**: Score > 2.0 — sustained relative outperformance; overweight bias
+- **STEADY**: Score 0.3–2.0 — moderate momentum; neutral-to-overweight
+- **DECELERATING**: Score −1.5–0.3 — losing momentum; neutral-to-underweight
+- **LAGGING**: Score < −1.5 — sustained underperformance; underweight bias
+- Use the quartile rankings to identify rotation opportunities (Q4→Q3 = improving; Q1→Q2 = deteriorating)
+
 ## Guidelines
 - Focus on momentum and relative strength metrics
 - Align sector recommendations with macro context from Phase 1

--- a/backend/analysis/agents/universe_builder.py
+++ b/backend/analysis/agents/universe_builder.py
@@ -18,10 +18,8 @@ from typing import Any
 
 import yfinance as yf  # type: ignore[import-untyped]
 
-from analysis.agents.heatmap_fetcher import (  # type: ignore[import-not-found]
-    FALLBACK_HOLDINGS,
-    SECTOR_ETFS,
-)
+from analysis.agents.heatmap_fetcher import FALLBACK_HOLDINGS  # type: ignore[import-not-found]
+from analysis.sectors import SECTOR_ETFS
 
 logger = logging.getLogger(__name__)
 

--- a/backend/analysis/autonomous_engine.py
+++ b/backend/analysis/autonomous_engine.py
@@ -1398,15 +1398,13 @@ class AutonomousDeepEngine:
             HeatmapData with sector and stock heatmap entries.
         """
         fetcher = get_heatmap_fetcher()
-        # Attempt to inject dynamic holdings into the fetcher
+        dynamic_holdings = None
         try:
             from analysis.agents.heatmap_fetcher import get_dynamic_holdings  # type: ignore[import-not-found]
             dynamic_holdings = await get_dynamic_holdings()
-            if dynamic_holdings:
-                fetcher._fallback_holdings = dynamic_holdings
         except Exception as exc:
             logger.debug("Dynamic holdings unavailable for heatmap fetch: %s", exc)
-        return await fetcher.fetch_heatmap_data()
+        return await fetcher.fetch_heatmap_data(holdings=dynamic_holdings or None)
 
     async def _run_heatmap_analysis(
         self,

--- a/backend/analysis/sector_momentum.py
+++ b/backend/analysis/sector_momentum.py
@@ -93,12 +93,8 @@ def compute_sector_momentum_from_heatmap(
         spy_5d = sum(all_5d) / len(all_5d) if all_5d else 0.0
         spy_20d = sum(all_20d) / len(all_20d) if all_20d else 0.0
 
-        class _FakeSPY:
-            change_5d = spy_5d
-            change_20d = spy_20d
-            change_60d: float | None = None
-
-        spy = _FakeSPY()  # type: ignore[assignment]
+        import types
+        spy = types.SimpleNamespace(change_5d=spy_5d, change_20d=spy_20d, change_60d=None)
 
     spy_1w = getattr(spy, "change_5d", 0.0) or 0.0
     spy_1m = getattr(spy, "change_20d", 0.0) or 0.0

--- a/backend/analysis/sector_momentum.py
+++ b/backend/analysis/sector_momentum.py
@@ -22,21 +22,9 @@ from typing import TYPE_CHECKING, Any
 if TYPE_CHECKING:
     from analysis.agents.heatmap_interfaces import SectorHeatmapEntry  # type: ignore[import-not-found]
 
-logger = logging.getLogger(__name__)
+from analysis.sectors import SECTOR_ETFS as SECTOR_ETF_NAMES  # noqa: F401 (live proxy, not a static copy)
 
-SECTOR_ETF_NAMES: dict[str, str] = {
-    "XLK": "Technology",
-    "XLF": "Financials",
-    "XLE": "Energy",
-    "XLV": "Healthcare",
-    "XLI": "Industrials",
-    "XLP": "Consumer Staples",
-    "XLY": "Consumer Discretionary",
-    "XLU": "Utilities",
-    "XLC": "Communication Services",
-    "XLRE": "Real Estate",
-    "XLB": "Materials",
-}
+logger = logging.getLogger(__name__)
 
 # Composite score weights
 WEIGHT_1W = 0.20

--- a/backend/analysis/sector_momentum.py
+++ b/backend/analysis/sector_momentum.py
@@ -1,0 +1,311 @@
+"""Sector relative strength momentum system.
+
+Computes quantitative momentum metrics for the 11 GICS sector ETFs relative
+to SPY across 1-week, 1-month, and 3-month timeframes. Produces ranked tables
+and rotation signals for LLM consumption.
+
+The module operates in two modes:
+1. From existing HeatmapData (fast, synchronous, uses change_5d/change_20d/change_60d)
+2. Fresh fetch (async, fetches its own 3-month price history)
+
+Integration point: format_heatmap_for_llm() in heatmap_fetcher.py appends the
+ranked momentum table to the heatmap context.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from analysis.agents.heatmap_interfaces import SectorHeatmapEntry  # type: ignore[import-not-found]
+
+logger = logging.getLogger(__name__)
+
+SECTOR_ETF_NAMES: dict[str, str] = {
+    "XLK": "Technology",
+    "XLF": "Financials",
+    "XLE": "Energy",
+    "XLV": "Healthcare",
+    "XLI": "Industrials",
+    "XLP": "Consumer Staples",
+    "XLY": "Consumer Discretionary",
+    "XLU": "Utilities",
+    "XLC": "Communication Services",
+    "XLRE": "Real Estate",
+    "XLB": "Materials",
+}
+
+# Composite score weights
+WEIGHT_1W = 0.20
+WEIGHT_1M = 0.40
+WEIGHT_3M = 0.40
+
+
+@dataclass
+class SectorMomentumData:
+    """Quantitative momentum metrics for a single sector ETF."""
+
+    symbol: str
+    sector: str
+    rs_1w: float = 0.0    # 1-week relative strength vs SPY (%)
+    rs_1m: float = 0.0    # 1-month relative strength vs SPY (%)
+    rs_3m: float = 0.0    # 3-month relative strength vs SPY (%)
+    abs_1w: float = 0.0   # absolute 1-week return (%)
+    abs_1m: float = 0.0   # absolute 1-month return (%)
+    abs_3m: float = 0.0   # absolute 3-month return (%)
+    momentum_score: float = 0.0  # composite: weighted RS across timeframes
+    rank: int = 0         # 1 = strongest momentum
+    quartile: int = 2     # 1 = top quartile, 4 = bottom quartile
+    signal: str = "STEADY"  # ACCELERATING | STEADY | DECELERATING | LAGGING
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dict."""
+        return {
+            "symbol": self.symbol,
+            "sector": self.sector,
+            "rs_1w": self.rs_1w,
+            "rs_1m": self.rs_1m,
+            "rs_3m": self.rs_3m,
+            "abs_1w": self.abs_1w,
+            "abs_1m": self.abs_1m,
+            "abs_3m": self.abs_3m,
+            "momentum_score": self.momentum_score,
+            "rank": self.rank,
+            "quartile": self.quartile,
+            "signal": self.signal,
+        }
+
+
+def compute_sector_momentum_from_heatmap(
+    sectors: list[SectorHeatmapEntry],
+) -> list[SectorMomentumData]:
+    """Compute momentum rankings from existing HeatmapData sectors.
+
+    Uses change_5d (≈1W), change_20d (≈1M), and change_60d (≈3M, if available)
+    that are already fetched by the heatmap pipeline. No additional I/O needed.
+
+    Args:
+        sectors: List of SectorHeatmapEntry from HeatmapData.
+
+    Returns:
+        List of SectorMomentumData sorted by momentum_score descending.
+        Returns empty list if SPY benchmark is missing.
+    """
+    # Build lookup by ETF symbol
+    by_etf: dict[str, SectorHeatmapEntry] = {s.etf: s for s in sectors if s.etf}
+
+    spy = by_etf.get("SPY")
+    if not spy:
+        # Estimate SPY from sector average as fallback
+        all_5d = [s.change_5d for s in sectors if s.etf in SECTOR_ETF_NAMES]
+        all_20d = [s.change_20d for s in sectors if s.etf in SECTOR_ETF_NAMES]
+        spy_5d = sum(all_5d) / len(all_5d) if all_5d else 0.0
+        spy_20d = sum(all_20d) / len(all_20d) if all_20d else 0.0
+
+        class _FakeSPY:
+            change_5d = spy_5d
+            change_20d = spy_20d
+            change_60d: float | None = None
+
+        spy = _FakeSPY()  # type: ignore[assignment]
+
+    spy_1w = getattr(spy, "change_5d", 0.0) or 0.0
+    spy_1m = getattr(spy, "change_20d", 0.0) or 0.0
+    spy_3m = getattr(spy, "change_60d", None)
+
+    results: list[SectorMomentumData] = []
+
+    for etf, name in SECTOR_ETF_NAMES.items():
+        s = by_etf.get(etf)
+        if not s:
+            continue
+
+        abs_1w = s.change_5d or 0.0
+        abs_1m = s.change_20d or 0.0
+        abs_3m = getattr(s, "change_60d", None)
+
+        rs_1w = round(abs_1w - spy_1w, 2)
+        rs_1m = round(abs_1m - spy_1m, 2)
+
+        # 3M: use if both available, otherwise weight down
+        if abs_3m is not None and spy_3m is not None:
+            rs_3m = round(abs_3m - spy_3m, 2)
+            score = round(WEIGHT_1W * rs_1w + WEIGHT_1M * rs_1m + WEIGHT_3M * rs_3m, 3)
+        else:
+            rs_3m = 0.0
+            # Rebalance weights to 1W + 1M only
+            score = round(0.33 * rs_1w + 0.67 * rs_1m, 3)
+
+        results.append(SectorMomentumData(
+            symbol=etf,
+            sector=name,
+            rs_1w=rs_1w,
+            rs_1m=rs_1m,
+            rs_3m=rs_3m,
+            abs_1w=round(abs_1w, 2),
+            abs_1m=round(abs_1m, 2),
+            abs_3m=round(abs_3m, 2) if abs_3m is not None else 0.0,
+            momentum_score=score,
+        ))
+
+    return _assign_ranks_and_signals(results)
+
+
+async def compute_sector_momentum() -> list[SectorMomentumData]:
+    """Fetch fresh 3-month price data and compute full momentum rankings.
+
+    Fetches SPY + 11 sector ETFs via yfinance (3mo period) and computes
+    1W, 1M, 3M relative strength independently of the heatmap pipeline.
+    Intended for standalone use or when heatmap data is not yet available.
+
+    Returns:
+        List of SectorMomentumData sorted by momentum_score descending.
+    """
+    try:
+        import yfinance as yf
+        loop = asyncio.get_running_loop()
+
+        symbols = ["SPY"] + list(SECTOR_ETF_NAMES.keys())
+
+        async def _fetch(sym: str) -> tuple[str, Any]:
+            ticker = yf.Ticker(sym)
+            hist = await loop.run_in_executor(
+                None, lambda t=ticker: t.history(period="3mo")
+            )
+            return sym, hist
+
+        raw = await asyncio.gather(*[_fetch(s) for s in symbols], return_exceptions=True)
+
+        price_data: dict[str, dict[str, float]] = {}
+        for r in raw:
+            if isinstance(r, Exception):
+                continue
+            sym, hist = r
+            if hist is None or hist.empty or len(hist) < 5:
+                continue
+            closes = hist["Close"]
+            cur = float(closes.iloc[-1])
+
+            def _ret(n: int) -> float:
+                if len(closes) >= n:
+                    ref = float(closes.iloc[-n])
+                    return ((cur / ref) - 1) * 100 if ref else 0.0
+                return 0.0
+
+            price_data[sym] = {
+                "r_1w": round(_ret(5), 2),
+                "r_1m": round(_ret(21), 2),
+                "r_3m": round(_ret(63), 2),
+            }
+
+        spy_d = price_data.get("SPY", {"r_1w": 0.0, "r_1m": 0.0, "r_3m": 0.0})
+        results: list[SectorMomentumData] = []
+
+        for etf, name in SECTOR_ETF_NAMES.items():
+            d = price_data.get(etf)
+            if not d:
+                continue
+            rs_1w = round(d["r_1w"] - spy_d["r_1w"], 2)
+            rs_1m = round(d["r_1m"] - spy_d["r_1m"], 2)
+            rs_3m = round(d["r_3m"] - spy_d["r_3m"], 2)
+            score = round(WEIGHT_1W * rs_1w + WEIGHT_1M * rs_1m + WEIGHT_3M * rs_3m, 3)
+
+            results.append(SectorMomentumData(
+                symbol=etf,
+                sector=name,
+                rs_1w=rs_1w,
+                rs_1m=rs_1m,
+                rs_3m=rs_3m,
+                abs_1w=d["r_1w"],
+                abs_1m=d["r_1m"],
+                abs_3m=d["r_3m"],
+                momentum_score=score,
+            ))
+
+        return _assign_ranks_and_signals(results)
+
+    except Exception as e:
+        logger.warning(f"Sector momentum fetch failed: {e}")
+        return []
+
+
+def _assign_ranks_and_signals(data: list[SectorMomentumData]) -> list[SectorMomentumData]:
+    """Sort by score, assign rank, quartile, and signal labels."""
+    data.sort(key=lambda x: x.momentum_score, reverse=True)
+    n = len(data)
+
+    for i, item in enumerate(data):
+        item.rank = i + 1
+        # Quartile: 1=top 25%, 4=bottom 25%
+        rank_pct = i / max(n - 1, 1)
+        item.quartile = min(int(rank_pct * 4) + 1, 4)
+
+        # Signal based on composite score magnitude
+        if item.momentum_score > 2.0:
+            item.signal = "ACCELERATING"
+        elif item.momentum_score > 0.3:
+            item.signal = "STEADY"
+        elif item.momentum_score > -1.5:
+            item.signal = "DECELERATING"
+        else:
+            item.signal = "LAGGING"
+
+    return data
+
+
+def format_momentum_table(momentum_data: list[SectorMomentumData]) -> str:
+    """Format sector momentum rankings as a text table for LLM consumption.
+
+    Args:
+        momentum_data: List of SectorMomentumData (sorted by score).
+
+    Returns:
+        Formatted string with ranked table and rotation signals section.
+        Returns empty string if momentum_data is empty.
+    """
+    if not momentum_data:
+        return ""
+
+    has_3m = any(d.rs_3m != 0.0 for d in momentum_data)
+
+    lines: list[str] = ["=== SECTOR MOMENTUM RANKINGS (Relative to SPY) ==="]
+
+    if has_3m:
+        header = f"{'Rank':<5} {'ETF':<6} {'Sector':<22} {'1W RS':>7} {'1M RS':>7} {'3M RS':>7} {'Score':>7}  Signal"
+        divider = "-" * 73
+    else:
+        header = f"{'Rank':<5} {'ETF':<6} {'Sector':<22} {'1W RS':>7} {'1M RS':>7} {'Score':>7}  Signal"
+        divider = "-" * 63
+
+    lines += [header, divider]
+
+    for d in momentum_data:
+        if has_3m:
+            lines.append(
+                f"{d.rank:<5} {d.symbol:<6} {d.sector:<22} "
+                f"{d.rs_1w:>+6.1f}% {d.rs_1m:>+6.1f}% {d.rs_3m:>+6.1f}% "
+                f"{d.momentum_score:>+6.2f}  {d.signal}"
+            )
+        else:
+            lines.append(
+                f"{d.rank:<5} {d.symbol:<6} {d.sector:<22} "
+                f"{d.rs_1w:>+6.1f}% {d.rs_1m:>+6.1f}% "
+                f"{d.momentum_score:>+6.2f}  {d.signal}"
+            )
+
+    # Rotation signals summary
+    accelerating = [d for d in momentum_data if d.signal == "ACCELERATING"]
+    lagging = [d for d in momentum_data if d.signal == "LAGGING"]
+
+    if accelerating or lagging:
+        lines.append("")
+        lines.append("ROTATION SIGNALS:")
+        for d in accelerating[:3]:
+            lines.append(f"  + {d.symbol} ({d.sector}): momentum accelerating (score {d.momentum_score:+.2f})")
+        for d in lagging[:3]:
+            lines.append(f"  - {d.symbol} ({d.sector}): momentum lagging (score {d.momentum_score:+.2f})")
+
+    return "\n".join(lines)

--- a/backend/analysis/sectors.py
+++ b/backend/analysis/sectors.py
@@ -8,11 +8,14 @@ This module provides sector analysis capabilities including:
 - Actionable sector insights generation
 """
 
-from typing import Any, Optional
-from datetime import datetime
-from dataclasses import dataclass
-from enum import Enum
+import logging
 import statistics
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
 
 
 class SectorPhase(Enum):
@@ -108,17 +111,25 @@ async def load_sector_etfs_from_db() -> None:
                 etfs = json.loads(row.value)
                 if isinstance(etfs, dict) and etfs:
                     set_sector_etfs(etfs)
-    except Exception:
-        pass  # Non-fatal — defaults remain active
+    except Exception as exc:
+        logger.debug("sector_etfs DB load failed: %s", exc)  # Non-fatal — defaults remain active
 
 
 # Backwards-compatible alias so existing imports of SECTOR_ETFS still work.
 # Always reflects the live cache value via get_sector_etfs().
 class _SectorEtfsProxy(dict):
-    """Proxy dict that delegates all lookups to get_sector_etfs().
+    """Read-only proxy dict that delegates all lookups to get_sector_etfs().
 
-    Allows legacy ``from analysis.sectors import SECTOR_ETFS`` code to work
-    without changes while still reflecting runtime-configured values.
+    Allows ``from analysis.sectors import SECTOR_ETFS`` to keep working while
+    always reflecting the live runtime-configured value.
+
+    Intentionally omitted (not needed by any caller, would silently mutate the
+    proxy object rather than the live cache — use set_sector_etfs() instead):
+        __setitem__, __delitem__, update(), pop(), popitem(), setdefault(), clear()
+
+    Also omitted: __eq__, __hash__ — equality checks against a plain dict will
+    fall back to dict.__eq__ using the proxy's own (empty) contents, which is
+    misleading. Compare get_sector_etfs() directly if equality is needed.
     """
 
     def __getitem__(self, key: str) -> str:

--- a/backend/analysis/sectors.py
+++ b/backend/analysis/sectors.py
@@ -48,8 +48,9 @@ class SectorMetrics:
     volatility: float = 0.0  # Standard deviation of returns
 
 
-# Sector ETF mappings
-SECTOR_ETFS: dict[str, str] = {
+# Default sector ETF mappings — overridable at runtime via settings DB.
+# Use get_sector_etfs() to read the live value throughout the codebase.
+DEFAULT_SECTOR_ETFS: dict[str, str] = {
     "XLK": "Technology",
     "XLV": "Health Care",
     "XLF": "Financials",
@@ -62,6 +63,93 @@ SECTOR_ETFS: dict[str, str] = {
     "XLRE": "Real Estate",
     "XLC": "Communication Services",
 }
+
+# In-memory cache — populated from settings DB on startup via load_sector_etfs_from_db().
+# Falls back to DEFAULT_SECTOR_ETFS if not yet loaded.
+_sector_etfs_cache: dict[str, str] | None = None
+
+
+def get_sector_etfs() -> dict[str, str]:
+    """Return the current sector ETF mapping.
+
+    Uses the in-memory cache if populated (loaded from settings DB on startup),
+    otherwise falls back to DEFAULT_SECTOR_ETFS.
+    """
+    return _sector_etfs_cache if _sector_etfs_cache is not None else DEFAULT_SECTOR_ETFS
+
+
+def set_sector_etfs(etfs: dict[str, str]) -> None:
+    """Update the in-memory sector ETF cache.
+
+    Called on startup after loading from DB, and whenever the setting is saved.
+    """
+    global _sector_etfs_cache
+    _sector_etfs_cache = etfs
+
+
+async def load_sector_etfs_from_db() -> None:
+    """Load sector ETFs from settings DB into the in-memory cache.
+
+    Should be called once on application startup. Silently falls back to
+    defaults if the setting has not been configured.
+    """
+    try:
+        from database import AsyncSessionLocal
+        from models.settings import UserSettings
+        from sqlalchemy import select
+        import json
+
+        async with AsyncSessionLocal() as session:
+            result = await session.execute(
+                select(UserSettings).where(UserSettings.key == "sector_etfs")
+            )
+            row = result.scalar_one_or_none()
+            if row:
+                etfs = json.loads(row.value)
+                if isinstance(etfs, dict) and etfs:
+                    set_sector_etfs(etfs)
+    except Exception:
+        pass  # Non-fatal — defaults remain active
+
+
+# Backwards-compatible alias so existing imports of SECTOR_ETFS still work.
+# Always reflects the live cache value via get_sector_etfs().
+class _SectorEtfsProxy(dict):
+    """Proxy dict that delegates all lookups to get_sector_etfs().
+
+    Allows legacy ``from analysis.sectors import SECTOR_ETFS`` code to work
+    without changes while still reflecting runtime-configured values.
+    """
+
+    def __getitem__(self, key: str) -> str:
+        return get_sector_etfs()[key]
+
+    def __contains__(self, key: object) -> bool:
+        return key in get_sector_etfs()
+
+    def __iter__(self):
+        return iter(get_sector_etfs())
+
+    def __len__(self) -> int:
+        return len(get_sector_etfs())
+
+    def get(self, key: str, default: str | None = None) -> str | None:  # type: ignore[override]
+        return get_sector_etfs().get(key, default)
+
+    def keys(self):
+        return get_sector_etfs().keys()
+
+    def values(self):
+        return get_sector_etfs().values()
+
+    def items(self):
+        return get_sector_etfs().items()
+
+    def copy(self) -> dict[str, str]:
+        return get_sector_etfs().copy()
+
+
+SECTOR_ETFS: dict[str, str] = _SectorEtfsProxy()  # type: ignore[assignment]
 
 
 class SectorAnalyzer:

--- a/backend/api/routes/settings.py
+++ b/backend/api/routes/settings.py
@@ -246,6 +246,10 @@ async def update_setting(
     like /llm and /watchlist are matched first by FastAPI.
     """
     setting = await service.set_setting(key, update.value)
+    # Invalidate in-memory caches for settings that back live data structures
+    if key == "sector_etfs" and isinstance(update.value, dict):
+        from analysis.sectors import set_sector_etfs
+        set_sector_etfs(update.value)
     return {
         "key": setting.key,
         "value": json.loads(setting.value),

--- a/backend/main.py
+++ b/backend/main.py
@@ -216,6 +216,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     from services.llm_settings import load_llm_settings_on_startup
     async with async_session_factory() as session:
         await load_llm_settings_on_startup(session)
+    # Load sector ETF configuration from database into in-memory cache
+    from analysis.sectors import load_sector_etfs_from_db
+    await load_sector_etfs_from_db()
     # Mark any leftover in-progress analysis tasks as failed
     await _cleanup_stale_analysis_tasks()
     # Start ETL scheduler for background data fetching

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -12,19 +12,6 @@ from models.settings import UserSettings
 # Default settings configuration
 DEFAULT_SETTINGS: dict[str, Any] = {
     "watchlist_symbols": ["AAPL", "GOOGL", "MSFT", "AMZN", "NVDA"],
-    "sector_etfs": {
-        "XLK": "Technology",
-        "XLV": "Health Care",
-        "XLF": "Financials",
-        "XLY": "Consumer Discretionary",
-        "XLP": "Consumer Staples",
-        "XLE": "Energy",
-        "XLI": "Industrials",
-        "XLB": "Materials",
-        "XLU": "Utilities",
-        "XLRE": "Real Estate",
-        "XLC": "Communication Services",
-    },
     "refresh_interval": 5,  # minutes: 1, 5, 15, 30
     "theme": "system",  # "light", "dark", "system"
     "chart_type": "candlestick",  # "candlestick", "line", "area"
@@ -48,8 +35,10 @@ class SettingsService:
         result = await self.db.execute(select(UserSettings))
         stored_settings = result.scalars().all()
 
-        # Start with defaults
+        # Start with defaults — sector_etfs comes from analysis.sectors (single source)
+        from analysis.sectors import get_sector_etfs
         settings = DEFAULT_SETTINGS.copy()
+        settings["sector_etfs"] = get_sector_etfs()
 
         # Override with stored values
         for setting in stored_settings:
@@ -73,7 +62,10 @@ class SettingsService:
             except json.JSONDecodeError:
                 return setting.value
 
-        # Return default if exists
+        # Return default if exists — sector_etfs defers to analysis.sectors
+        if key == "sector_etfs":
+            from analysis.sectors import get_sector_etfs
+            return get_sector_etfs()
         return DEFAULT_SETTINGS.get(key)
 
     async def set_setting(self, key: str, value: Any) -> UserSettings:

--- a/backend/services/settings.py
+++ b/backend/services/settings.py
@@ -12,6 +12,19 @@ from models.settings import UserSettings
 # Default settings configuration
 DEFAULT_SETTINGS: dict[str, Any] = {
     "watchlist_symbols": ["AAPL", "GOOGL", "MSFT", "AMZN", "NVDA"],
+    "sector_etfs": {
+        "XLK": "Technology",
+        "XLV": "Health Care",
+        "XLF": "Financials",
+        "XLY": "Consumer Discretionary",
+        "XLP": "Consumer Staples",
+        "XLE": "Energy",
+        "XLI": "Industrials",
+        "XLB": "Materials",
+        "XLU": "Utilities",
+        "XLRE": "Real Estate",
+        "XLC": "Communication Services",
+    },
     "refresh_interval": 5,  # minutes: 1, 5, 15, 30
     "theme": "system",  # "light", "dark", "system"
     "chart_type": "candlestick",  # "candlestick", "line", "area"

--- a/backend/tests/test_options_signals.py
+++ b/backend/tests/test_options_signals.py
@@ -1,0 +1,255 @@
+"""Tests for options-implied signals module."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+import pandas as pd
+
+from analysis.agents.options_signals import (
+    OptionsSignals,
+    fetch_options_signals,
+    PC_RATIO_AVG,
+    PC_COMPLACENT_THRESHOLD,
+    PC_FEARFUL_THRESHOLD,
+)
+
+
+# =============================================================================
+# OptionsSignals.format_block
+# =============================================================================
+
+
+class TestOptionsSignalsFormatBlock:
+    def test_unavailable_returns_empty(self):
+        signals = OptionsSignals(available=False)
+        assert signals.format_block() == ""
+
+    def test_vix_only(self):
+        signals = OptionsSignals(vix=18.5, vix_percentile_52w=45.0, available=True)
+        block = signals.format_block()
+        assert "OPTIONS SENTIMENT" in block
+        assert "18.5" in block
+        assert "45%" in block
+
+    def test_contango_term_structure(self):
+        signals = OptionsSignals(
+            vix=14.0, vix3m=17.5,
+            term_structure="contango", term_structure_spread=3.5,
+            available=True,
+        )
+        block = signals.format_block()
+        assert "Contango" in block
+        assert "calm" in block
+
+    def test_backwardation_term_structure(self):
+        signals = OptionsSignals(
+            vix=25.0, vix3m=20.0,
+            term_structure="backwardation", term_structure_spread=-5.0,
+            available=True,
+        )
+        block = signals.format_block()
+        assert "Backwardation" in block
+        assert "stressed" in block
+
+    def test_elevated_skew(self):
+        signals = OptionsSignals(skew=140.0, available=True)
+        block = signals.format_block()
+        assert "140" in block
+        assert "tail-risk" in block
+
+    def test_complacent_pc_ratio(self):
+        signals = OptionsSignals(put_call_ratio=0.55, pc_signal="complacent", available=True)
+        block = signals.format_block()
+        assert "0.55" in block
+        assert "complacent" in block
+
+    def test_fearful_pc_ratio(self):
+        signals = OptionsSignals(put_call_ratio=1.35, pc_signal="fearful", available=True)
+        block = signals.format_block()
+        assert "1.35" in block
+        assert "fearful" in block
+
+    def test_low_vix_percentile_label(self):
+        signals = OptionsSignals(vix=12.0, vix_percentile_52w=15.0, available=True)
+        block = signals.format_block()
+        assert "complacency" in block
+
+    def test_high_vix_percentile_label(self):
+        signals = OptionsSignals(vix=30.0, vix_percentile_52w=82.0, available=True)
+        block = signals.format_block()
+        assert "fear" in block
+
+
+# =============================================================================
+# Term structure classification
+# =============================================================================
+
+
+class TestTermStructureClassification:
+    def _make_signals(self, vix: float, vix3m: float) -> OptionsSignals:
+        spread = vix3m - vix
+        if spread > 1.0:
+            ts = "contango"
+        elif spread < -1.0:
+            ts = "backwardation"
+        else:
+            ts = "flat"
+        return OptionsSignals(
+            vix=vix, vix3m=vix3m,
+            term_structure=ts, term_structure_spread=round(spread, 2),
+            available=True,
+        )
+
+    def test_contango_positive_spread(self):
+        s = self._make_signals(14.0, 18.0)
+        assert s.term_structure == "contango"
+        assert s.term_structure_spread == pytest.approx(4.0)
+
+    def test_backwardation_negative_spread(self):
+        s = self._make_signals(28.0, 22.0)
+        assert s.term_structure == "backwardation"
+        assert s.term_structure_spread == pytest.approx(-6.0)
+
+    def test_flat_small_spread(self):
+        s = self._make_signals(20.0, 20.5)
+        assert s.term_structure == "flat"
+
+
+# =============================================================================
+# VIX percentile computation
+# =============================================================================
+
+
+class TestVixPercentile:
+    def test_low_vix_in_high_hist_gives_low_percentile(self):
+        # Current VIX = 10, history was all 20+
+        current = 10.0
+        hist = [25.0, 22.0, 23.0, 21.0, 24.0]
+        below = sum(1 for v in hist if v <= current)
+        pct = (below / len(hist)) * 100
+        assert pct == 0.0
+
+    def test_high_vix_gives_high_percentile(self):
+        current = 40.0
+        hist = [10.0, 12.0, 15.0, 18.0, 20.0]
+        below = sum(1 for v in hist if v <= current)
+        pct = (below / len(hist)) * 100
+        assert pct == 100.0
+
+    def test_median_vix_percentile(self):
+        # Current right at median of sorted history
+        hist = [10.0, 15.0, 20.0, 25.0, 30.0]
+        current = 20.0
+        below = sum(1 for v in hist if v <= current)
+        pct = (below / len(hist)) * 100
+        assert pct == 60.0  # 3 of 5 are <= 20
+
+
+# =============================================================================
+# Put/call ratio signal thresholds
+# =============================================================================
+
+
+class TestPutCallRatioThresholds:
+    def test_below_complacent_threshold(self):
+        ratio = PC_COMPLACENT_THRESHOLD - 0.1
+        signal = "complacent" if ratio < PC_COMPLACENT_THRESHOLD else "neutral"
+        assert signal == "complacent"
+
+    def test_above_fearful_threshold(self):
+        ratio = PC_FEARFUL_THRESHOLD + 0.1
+        signal = "fearful" if ratio > PC_FEARFUL_THRESHOLD else "neutral"
+        assert signal == "fearful"
+
+    def test_between_thresholds_is_neutral(self):
+        ratio = (PC_COMPLACENT_THRESHOLD + PC_FEARFUL_THRESHOLD) / 2
+        if ratio < PC_COMPLACENT_THRESHOLD:
+            signal = "complacent"
+        elif ratio > PC_FEARFUL_THRESHOLD:
+            signal = "fearful"
+        else:
+            signal = "neutral"
+        assert signal == "neutral"
+
+
+# =============================================================================
+# fetch_options_signals (mocked yfinance)
+# =============================================================================
+
+
+@pytest.fixture
+def mock_vix_history():
+    """1-year VIX close prices (current = 16.5, 52w range 10-30)."""
+    closes = list(range(10, 31)) * 12 + [16.5]  # 252 values ending at 16.5
+    return pd.DataFrame({"Close": closes})
+
+
+@pytest.fixture
+def mock_vix3m_history():
+    return pd.DataFrame({"Close": [19.2, 19.0, 19.5, 19.3, 19.4]})
+
+
+@pytest.fixture
+def mock_skew_history():
+    return pd.DataFrame({"Close": [128.0, 129.0, 130.0, 131.0, 132.0]})
+
+
+@pytest.fixture
+def mock_spy_chain():
+    """Minimal SPY option chain with puts > calls (fearful)."""
+    puts = pd.DataFrame({"volume": [500, 600, 700]})
+    calls = pd.DataFrame({"volume": [300, 400, 200]})
+    chain = MagicMock()
+    chain.puts = puts
+    chain.calls = calls
+    return chain
+
+
+class TestFetchOptionsSignals:
+    @pytest.mark.asyncio
+    async def test_returns_signals_with_mocked_data(
+        self, mock_vix_history, mock_vix3m_history, mock_skew_history, mock_spy_chain
+    ):
+        mock_vix_ticker = MagicMock()
+        mock_vix_ticker.history.return_value = mock_vix_history
+
+        mock_vix3m_ticker = MagicMock()
+        mock_vix3m_ticker.history.return_value = mock_vix3m_history
+
+        mock_skew_ticker = MagicMock()
+        mock_skew_ticker.history.return_value = mock_skew_history
+
+        mock_spy_ticker = MagicMock()
+        mock_spy_ticker.options = ["2024-01-19"]
+        mock_spy_ticker.option_chain.return_value = mock_spy_chain
+
+        ticker_map = {
+            "^VIX": mock_vix_ticker,
+            "^VIX3M": mock_vix3m_ticker,
+            "^SKEW": mock_skew_ticker,
+            "SPY": mock_spy_ticker,
+        }
+
+        mock_yf = MagicMock()
+        mock_yf.Ticker.side_effect = lambda sym: ticker_map[sym]
+
+        with patch.dict("sys.modules", {"yfinance": mock_yf}):
+            signals = await fetch_options_signals()
+
+        assert signals.available is True
+        assert signals.vix > 0
+        assert signals.vix3m > 0
+        assert signals.skew > 0
+        assert 0.0 <= signals.vix_percentile_52w <= 100.0
+
+    @pytest.mark.asyncio
+    async def test_graceful_degradation_on_error(self):
+        """fetch_options_signals should not raise on yfinance failures."""
+        with patch("analysis.agents.options_signals.asyncio.get_running_loop") as mock_loop:
+            loop = AsyncMock()
+            mock_loop.return_value = loop
+            loop.run_in_executor = AsyncMock(side_effect=Exception("network error"))
+
+            signals = await fetch_options_signals()
+
+        assert signals.available is False
+        assert signals.vix == 0.0

--- a/backend/tests/test_sector_momentum.py
+++ b/backend/tests/test_sector_momentum.py
@@ -1,0 +1,258 @@
+"""Tests for sector relative strength momentum system."""
+
+import pytest
+
+from analysis.agents.heatmap_interfaces import SectorHeatmapEntry
+from analysis.sector_momentum import (
+    SectorMomentumData,
+    SECTOR_ETF_NAMES,
+    WEIGHT_1W,
+    WEIGHT_1M,
+    WEIGHT_3M,
+    compute_sector_momentum_from_heatmap,
+    format_momentum_table,
+    _assign_ranks_and_signals,
+)
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def make_sector(etf: str, change_1d=0.0, change_5d=0.0, change_20d=0.0, change_60d=None):
+    name = SECTOR_ETF_NAMES.get(etf, etf)
+    return SectorHeatmapEntry(
+        name=name,
+        etf=etf,
+        change_1d=change_1d,
+        change_5d=change_5d,
+        change_20d=change_20d,
+        change_60d=change_60d,
+    )
+
+
+def make_spy(change_5d=0.0, change_20d=0.0, change_60d=None):
+    entry = SectorHeatmapEntry(name="S&P 500", etf="SPY")
+    entry.change_5d = change_5d
+    entry.change_20d = change_20d
+    entry.change_60d = change_60d
+    return entry
+
+
+# =============================================================================
+# compute_sector_momentum_from_heatmap
+# =============================================================================
+
+
+class TestComputeSectorMomentumFromHeatmap:
+    def test_returns_all_sectors_with_data(self):
+        sectors = [make_spy()] + [make_sector(etf) for etf in SECTOR_ETF_NAMES]
+        result = compute_sector_momentum_from_heatmap(sectors)
+        assert len(result) == len(SECTOR_ETF_NAMES)
+
+    def test_missing_sectors_skipped(self):
+        # Only 3 sectors + SPY
+        sectors = [make_spy(), make_sector("XLK"), make_sector("XLF"), make_sector("XLE")]
+        result = compute_sector_momentum_from_heatmap(sectors)
+        assert len(result) == 3
+
+    def test_relative_strength_computation(self):
+        """RS should be sector return minus SPY return."""
+        spy = make_spy(change_5d=1.0, change_20d=2.0)
+        xlk = make_sector("XLK", change_5d=3.0, change_20d=5.0)
+        result = compute_sector_momentum_from_heatmap([spy, xlk])
+        assert len(result) == 1
+        data = result[0]
+        assert data.rs_1w == pytest.approx(2.0)   # 3.0 - 1.0
+        assert data.rs_1m == pytest.approx(3.0)   # 5.0 - 2.0
+
+    def test_momentum_score_with_3m(self):
+        """Score = 0.2*rs_1w + 0.4*rs_1m + 0.4*rs_3m when 3M available."""
+        spy = make_spy(change_5d=1.0, change_20d=2.0, change_60d=3.0)
+        xlk = make_sector("XLK", change_5d=3.0, change_20d=6.0, change_60d=9.0)
+        result = compute_sector_momentum_from_heatmap([spy, xlk])
+        data = result[0]
+        expected = WEIGHT_1W * 2.0 + WEIGHT_1M * 4.0 + WEIGHT_3M * 6.0
+        assert data.momentum_score == pytest.approx(expected, abs=0.01)
+
+    def test_momentum_score_without_3m(self):
+        """When 3M missing, fallback to 1W/1M-only weights."""
+        spy = make_spy(change_5d=1.0, change_20d=2.0)
+        xlk = make_sector("XLK", change_5d=3.0, change_20d=6.0)
+        result = compute_sector_momentum_from_heatmap([spy, xlk])
+        data = result[0]
+        # Fallback: 0.33*rs_1w + 0.67*rs_1m
+        expected = 0.33 * 2.0 + 0.67 * 4.0
+        assert data.momentum_score == pytest.approx(expected, abs=0.05)
+
+    def test_sorted_by_score_descending(self):
+        spy = make_spy()
+        sectors = [
+            make_sector("XLU", change_20d=-5.0),
+            make_sector("XLK", change_20d=8.0),
+            make_sector("XLF", change_20d=2.0),
+        ]
+        result = compute_sector_momentum_from_heatmap([spy] + sectors)
+        scores = [d.momentum_score for d in result]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_rank_assignment(self):
+        spy = make_spy()
+        sectors = [make_sector(etf, change_20d=float(i)) for i, etf in enumerate(["XLK", "XLF", "XLE"])]
+        result = compute_sector_momentum_from_heatmap([spy] + sectors)
+        ranks = [d.rank for d in result]
+        assert sorted(ranks) == [1, 2, 3]
+
+    def test_no_spy_fallback(self):
+        """Without SPY, uses sector average as benchmark — still returns data."""
+        sectors = [make_sector("XLK", change_20d=5.0), make_sector("XLF", change_20d=-3.0)]
+        result = compute_sector_momentum_from_heatmap(sectors)
+        assert len(result) == 2
+
+    def test_empty_sectors_returns_empty(self):
+        result = compute_sector_momentum_from_heatmap([])
+        assert result == []
+
+
+# =============================================================================
+# _assign_ranks_and_signals
+# =============================================================================
+
+
+class TestAssignRanksAndSignals:
+    def _make_data(self, scores: list[float]) -> list[SectorMomentumData]:
+        etfs = list(SECTOR_ETF_NAMES.keys())
+        return [
+            SectorMomentumData(
+                symbol=etfs[i % len(etfs)],
+                sector="Test",
+                momentum_score=score,
+            )
+            for i, score in enumerate(scores)
+        ]
+
+    def test_accelerating_signal(self):
+        data = self._make_data([3.0])
+        result = _assign_ranks_and_signals(data)
+        assert result[0].signal == "ACCELERATING"
+
+    def test_steady_signal(self):
+        data = self._make_data([1.0])
+        result = _assign_ranks_and_signals(data)
+        assert result[0].signal == "STEADY"
+
+    def test_decelerating_signal(self):
+        data = self._make_data([-0.5])
+        result = _assign_ranks_and_signals(data)
+        assert result[0].signal == "DECELERATING"
+
+    def test_lagging_signal(self):
+        data = self._make_data([-2.5])
+        result = _assign_ranks_and_signals(data)
+        assert result[0].signal == "LAGGING"
+
+    def test_quartile_top(self):
+        scores = [4.0, 2.0, 1.0, 0.0, -1.0, -2.0, -3.0, -4.0]
+        data = self._make_data(scores)
+        result = _assign_ranks_and_signals(data)
+        assert result[0].quartile == 1   # top
+        assert result[-1].quartile == 4  # bottom
+
+    def test_rank_one_is_highest_score(self):
+        data = self._make_data([1.0, 5.0, 3.0])
+        result = _assign_ranks_and_signals(data)
+        assert result[0].rank == 1
+        assert result[0].momentum_score == pytest.approx(5.0)
+
+
+# =============================================================================
+# format_momentum_table
+# =============================================================================
+
+
+class TestFormatMomentumTable:
+    def test_empty_returns_empty_string(self):
+        assert format_momentum_table([]) == ""
+
+    def test_header_present(self):
+        data = [SectorMomentumData(symbol="XLK", sector="Technology", rank=1, rs_1w=1.0, rs_1m=2.0, momentum_score=1.5, signal="STEADY")]
+        table = format_momentum_table(data)
+        assert "SECTOR MOMENTUM RANKINGS" in table
+        assert "XLK" in table
+
+    def test_rotation_signals_section(self):
+        accelerating = SectorMomentumData(
+            symbol="XLK", sector="Technology", rank=1,
+            rs_1w=3.0, rs_1m=4.0, momentum_score=3.5, signal="ACCELERATING",
+        )
+        lagging = SectorMomentumData(
+            symbol="XLU", sector="Utilities", rank=11,
+            rs_1w=-3.0, rs_1m=-4.0, momentum_score=-4.0, signal="LAGGING",
+        )
+        table = format_momentum_table([accelerating, lagging])
+        assert "ROTATION SIGNALS" in table
+        assert "XLK" in table
+        assert "XLU" in table
+
+    def test_no_rotation_section_when_all_steady(self):
+        data = [
+            SectorMomentumData(
+                symbol="XLK", sector="Technology", rank=1,
+                rs_1w=0.5, rs_1m=1.0, momentum_score=0.8, signal="STEADY",
+            )
+        ]
+        table = format_momentum_table(data)
+        assert "ROTATION SIGNALS" not in table
+
+    def test_3m_column_present_when_rs_3m_set(self):
+        data = [
+            SectorMomentumData(
+                symbol="XLK", sector="Technology", rank=1,
+                rs_1w=1.0, rs_1m=2.0, rs_3m=3.0, momentum_score=2.0, signal="ACCELERATING",
+            )
+        ]
+        table = format_momentum_table(data)
+        assert "3M RS" in table
+
+    def test_3m_column_absent_when_no_rs_3m(self):
+        data = [
+            SectorMomentumData(
+                symbol="XLK", sector="Technology", rank=1,
+                rs_1w=1.0, rs_1m=2.0, rs_3m=0.0, momentum_score=1.5, signal="STEADY",
+            )
+        ]
+        table = format_momentum_table(data)
+        assert "3M RS" not in table
+
+
+# =============================================================================
+# SectorHeatmapEntry change_60d field
+# =============================================================================
+
+
+class TestSectorHeatmapEntryChange60d:
+    def test_default_is_none(self):
+        entry = SectorHeatmapEntry(name="Technology", etf="XLK")
+        assert entry.change_60d is None
+
+    def test_set_and_serialise(self):
+        entry = SectorHeatmapEntry(name="Technology", etf="XLK", change_60d=5.5)
+        d = entry.to_dict()
+        assert "change_60d" in d
+        assert d["change_60d"] == pytest.approx(5.5)
+
+    def test_none_not_serialised(self):
+        entry = SectorHeatmapEntry(name="Technology", etf="XLK", change_60d=None)
+        d = entry.to_dict()
+        assert "change_60d" not in d
+
+    def test_from_dict_with_change_60d(self):
+        d = {"name": "Technology", "etf": "XLK", "change_60d": 7.25}
+        entry = SectorHeatmapEntry.from_dict(d)
+        assert entry.change_60d == pytest.approx(7.25)
+
+    def test_from_dict_without_change_60d(self):
+        d = {"name": "Technology", "etf": "XLK"}
+        entry = SectorHeatmapEntry.from_dict(d)
+        assert entry.change_60d is None


### PR DESCRIPTION
## Summary

- Adds options-implied signals (IV, put/call ratios, skew, term structure) for enhanced signal detection
- Adds sector momentum rankings to surface relative sector strength/weakness
- Integrates both features into the autonomous analysis pipeline

Closes #16
Closes #17

## Test plan
- [ ] Verify options signals appear in analysis output for optionable symbols
- [ ] Verify sector momentum rankings are included in heatmap/sector analysis
- [ ] Run backend tests: `uv run pytest`
- [ ] Confirm no regressions in existing deep analysis flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)