### PR TITLE
feat(auth): full JWT authentication — backend + frontend

### DIFF
--- a/backend/api/deps.py
+++ b/backend/api/deps.py
@@ -3,11 +3,17 @@
 from collections.abc import AsyncGenerator
 from typing import Annotated
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth import TokenType, verify_token
 from config import Settings, get_settings
 from database import get_session
+from models.user import User
+
+_bearer = HTTPBearer()
 
 
 async def get_db() -> AsyncGenerator[AsyncSession, None]:
@@ -16,6 +22,31 @@ async def get_db() -> AsyncGenerator[AsyncSession, None]:
         yield session
 
 
+async def get_current_user(
+    credentials: HTTPAuthorizationCredentials = Depends(_bearer),
+    db: AsyncSession = Depends(get_db),
+) -> User:
+    """Validate Bearer access token and return the authenticated user."""
+    try:
+        username = verify_token(credentials.credentials, TokenType.ACCESS)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+            headers={"WWW-Authenticate": "Bearer"},
+        ) from exc
+
+    result = await db.execute(select(User).where(User.username == username))
+    user = result.scalar_one_or_none()
+    if not user or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User not found or inactive",
+        )
+    return user
+
+
 # Type aliases for dependency injection
 DbSession = Annotated[AsyncSession, Depends(get_db)]
 AppSettings = Annotated[Settings, Depends(get_settings)]
+CurrentUser = Annotated[User, Depends(get_current_user)]

--- a/backend/api/routes/__init__.py
+++ b/backend/api/routes/__init__.py
@@ -1,8 +1,10 @@
 """API routes package - Combines all route modules."""
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 
+from api.deps import get_current_user
 from api.routes.analysis import router as analysis_router
+from api.routes.auth import router as auth_router
 from api.routes.chat import router as chat_router
 from api.routes.data import router as data_router
 from api.routes.deep_insights import router as deep_insights_router
@@ -26,26 +28,31 @@ from api.routes.thematic_insights import router as thematic_insights_router
 # Combined router for all routes
 router = APIRouter()
 
-# Include route modules
+# Public routes (no auth required)
 router.include_router(health_router, tags=["health"])
-router.include_router(analysis_router)
-router.include_router(chat_router)
-router.include_router(data_router, tags=["data"])
-router.include_router(deep_insights_router, prefix="/deep-insights", tags=["deep-insights"])
-router.include_router(insight_conversations_router, tags=["insight-conversations"])
-router.include_router(insight_modifications_router, tags=["insight-modifications"])
-router.include_router(insights_router)
-router.include_router(search_router)
-router.include_router(settings_router, tags=["settings"])
-router.include_router(statistical_features_router, tags=["features"])
-router.include_router(stocks_router, tags=["stocks"])
-router.include_router(outcomes_router, tags=["outcomes"])
-router.include_router(knowledge_router, prefix="/knowledge", tags=["knowledge"])
-router.include_router(portfolio_router, prefix="/portfolio", tags=["portfolio"])
-router.include_router(reports_router, prefix="/reports", tags=["reports"])
-router.include_router(research_router, tags=["research"])
-router.include_router(runs_router, prefix="/runs", tags=["runs"])
-router.include_router(export_router)
-router.include_router(thematic_insights_router, prefix="/thematic-insights", tags=["thematic-insights"])
+router.include_router(auth_router)
+
+# Protected routes — all require a valid Bearer access token
+_auth = [Depends(get_current_user)]
+
+router.include_router(analysis_router, dependencies=_auth)
+router.include_router(chat_router, dependencies=_auth)
+router.include_router(data_router, tags=["data"], dependencies=_auth)
+router.include_router(deep_insights_router, prefix="/deep-insights", tags=["deep-insights"], dependencies=_auth)
+router.include_router(insight_conversations_router, tags=["insight-conversations"], dependencies=_auth)
+router.include_router(insight_modifications_router, tags=["insight-modifications"], dependencies=_auth)
+router.include_router(insights_router, dependencies=_auth)
+router.include_router(search_router, dependencies=_auth)
+router.include_router(settings_router, tags=["settings"], dependencies=_auth)
+router.include_router(statistical_features_router, tags=["features"], dependencies=_auth)
+router.include_router(stocks_router, tags=["stocks"], dependencies=_auth)
+router.include_router(outcomes_router, tags=["outcomes"], dependencies=_auth)
+router.include_router(knowledge_router, prefix="/knowledge", tags=["knowledge"], dependencies=_auth)
+router.include_router(portfolio_router, prefix="/portfolio", tags=["portfolio"], dependencies=_auth)
+router.include_router(reports_router, prefix="/reports", tags=["reports"], dependencies=_auth)
+router.include_router(research_router, tags=["research"], dependencies=_auth)
+router.include_router(runs_router, prefix="/runs", tags=["runs"], dependencies=_auth)
+router.include_router(export_router, dependencies=_auth)
+router.include_router(thematic_insights_router, prefix="/thematic-insights", tags=["thematic-insights"], dependencies=_auth)
 
 __all__ = ["router"]

--- a/backend/api/routes/auth.py
+++ b/backend/api/routes/auth.py
@@ -1,0 +1,118 @@
+"""Authentication routes: login, refresh, me, logout."""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException, Response, Cookie, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.deps import get_db
+from auth import create_access_token, create_refresh_token, verify_token, verify_password, TokenType
+from models.user import User
+from schemas.auth import LoginRequest, TokenResponse, UserResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+_REFRESH_COOKIE = "refresh_token"
+_COOKIE_MAX_AGE = 7 * 24 * 3600  # 7 days in seconds
+
+
+def _set_refresh_cookie(response: Response, token: str) -> None:
+    response.set_cookie(
+        key=_REFRESH_COOKIE,
+        value=token,
+        httponly=True,
+        secure=True,          # HTTPS only (safe for local dev via localhost exception)
+        samesite="lax",
+        max_age=_COOKIE_MAX_AGE,
+        path="/api/v1/auth",  # Scoped to auth endpoints only
+    )
+
+
+async def _get_user(db: AsyncSession, username: str) -> User | None:
+    result = await db.execute(select(User).where(User.username == username))
+    return result.scalar_one_or_none()
+
+
+@router.post("/login", response_model=TokenResponse)
+async def login(
+    body: LoginRequest,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> TokenResponse:
+    """Authenticate with username + password. Returns access token and sets refresh cookie."""
+    user = await _get_user(db, body.username)
+    if not user or not verify_password(body.password, user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid credentials",
+        )
+    if not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Account disabled",
+        )
+
+    access_token = create_access_token(user.username)
+    refresh_token = create_refresh_token(user.username)
+    _set_refresh_cookie(response, refresh_token)
+
+    logger.info("User %r logged in", user.username)
+    return TokenResponse(access_token=access_token)
+
+
+@router.post("/refresh", response_model=TokenResponse)
+async def refresh(
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+    refresh_token: str | None = Cookie(default=None, alias=_REFRESH_COOKIE),
+) -> TokenResponse:
+    """Issue a new access token using the refresh token cookie."""
+    if not refresh_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="No refresh token")
+
+    try:
+        username = verify_token(refresh_token, TokenType.REFRESH)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+
+    user = await _get_user(db, username)
+    if not user or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found or inactive")
+
+    new_access = create_access_token(user.username)
+    new_refresh = create_refresh_token(user.username)
+    _set_refresh_cookie(response, new_refresh)
+
+    return TokenResponse(access_token=new_access)
+
+
+@router.get("/me", response_model=UserResponse)
+async def me(
+    db: AsyncSession = Depends(get_db),
+    refresh_token: str | None = Cookie(default=None, alias=_REFRESH_COOKIE),
+) -> UserResponse:
+    """Return the current user based on the refresh token (used on page load)."""
+    if not refresh_token:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    try:
+        username = verify_token(refresh_token, TokenType.REFRESH)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=str(exc)) from exc
+
+    user = await _get_user(db, username)
+    if not user or not user.is_active:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="User not found")
+    return UserResponse(username=user.username, is_active=user.is_active)
+
+
+@router.post("/logout")
+async def logout(response: Response) -> dict:
+    """Clear the refresh token cookie."""
+    response.delete_cookie(key=_REFRESH_COOKIE, path="/api/v1/auth")
+    return {"detail": "Logged out"}

--- a/backend/auth/__init__.py
+++ b/backend/auth/__init__.py
@@ -1,0 +1,18 @@
+"""Authentication utilities: JWT token handling and password hashing."""
+
+from auth.jwt import (
+    create_access_token,
+    create_refresh_token,
+    verify_token,
+    TokenType,
+)
+from auth.password import hash_password, verify_password
+
+__all__ = [
+    "create_access_token",
+    "create_refresh_token",
+    "verify_token",
+    "TokenType",
+    "hash_password",
+    "verify_password",
+]

--- a/backend/auth/jwt.py
+++ b/backend/auth/jwt.py
@@ -1,0 +1,63 @@
+"""JWT token creation and verification."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any
+
+from jose import JWTError, jwt
+
+logger = logging.getLogger(__name__)
+
+
+class TokenType(str, Enum):
+    ACCESS = "access"
+    REFRESH = "refresh"
+
+
+def _settings():
+    from config import get_settings
+    return get_settings()
+
+
+def create_access_token(subject: str) -> str:
+    """Create a short-lived access token for *subject* (username)."""
+    s = _settings()
+    expire = datetime.now(timezone.utc) + timedelta(minutes=s.ACCESS_TOKEN_EXPIRE_MINUTES)
+    return _encode({"sub": subject, "type": TokenType.ACCESS, "exp": expire})
+
+
+def create_refresh_token(subject: str) -> str:
+    """Create a long-lived refresh token for *subject* (username)."""
+    s = _settings()
+    expire = datetime.now(timezone.utc) + timedelta(days=s.REFRESH_TOKEN_EXPIRE_DAYS)
+    return _encode({"sub": subject, "type": TokenType.REFRESH, "exp": expire})
+
+
+def verify_token(token: str, expected_type: TokenType) -> str:
+    """Decode *token* and return the subject (username).
+
+    Raises ValueError if the token is invalid, expired, or wrong type.
+    """
+    s = _settings()
+    try:
+        payload = jwt.decode(token, s.JWT_SECRET_KEY, algorithms=[s.JWT_ALGORITHM])
+    except JWTError as exc:
+        raise ValueError(f"Invalid token: {exc}") from exc
+
+    sub: str | None = payload.get("sub")
+    token_type: str | None = payload.get("type")
+
+    if not sub:
+        raise ValueError("Token missing subject")
+    if token_type != expected_type:
+        raise ValueError(f"Expected {expected_type} token, got {token_type!r}")
+
+    return sub
+
+
+def _encode(claims: dict[str, Any]) -> str:
+    s = _settings()
+    return jwt.encode(claims, s.JWT_SECRET_KEY, algorithm=s.JWT_ALGORITHM)

--- a/backend/auth/password.py
+++ b/backend/auth/password.py
@@ -1,0 +1,15 @@
+"""Password hashing utilities using bcrypt via passlib."""
+
+from passlib.context import CryptContext
+
+_ctx = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(plain: str) -> str:
+    """Return a bcrypt hash of the given plaintext password."""
+    return _ctx.hash(plain)
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    """Return True if *plain* matches *hashed*."""
+    return _ctx.verify(plain, hashed)

--- a/backend/config.py
+++ b/backend/config.py
@@ -55,6 +55,22 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     API_V1_PREFIX: str = "/api/v1"
 
+    # --- Authentication ---
+    # Generate a strong secret: python -c "import secrets; print(secrets.token_hex(32))"
+    JWT_SECRET_KEY: str = "change-me-in-production-use-secrets-token-hex-32"
+    JWT_ALGORITHM: str = "HS256"
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
+    # Admin credentials — set via env vars (ADMIN_USERNAME / ADMIN_PASSWORD)
+    ADMIN_USERNAME: str = "admin"
+    ADMIN_PASSWORD: str = "changeme"
+
+    # --- CORS ---
+    # Comma-separated list of allowed origins for production deployment.
+    # Localhost origins are always allowed in addition to these.
+    # Example: CORS_ORIGINS=https://myapp.fly.dev,https://myapp.vercel.app
+    CORS_ORIGINS: str = ""
+
     # Data Source Integrations
     PREDICTION_MARKETS_ENABLED: bool = True
     REDDIT_SENTIMENT_ENABLED: bool = True

--- a/backend/main.py
+++ b/backend/main.py
@@ -103,6 +103,23 @@ def _print_startup_banner() -> None:
     print(banner, flush=True)  # noqa: T201 — intentional print for startup visibility
 
 
+def _warn_insecure_defaults() -> None:
+    """Log prominent warnings if auth is configured with known-insecure defaults."""
+    s = get_settings()
+    if s.JWT_SECRET_KEY == "change-me-in-production-use-secrets-token-hex-32":
+        print(  # noqa: T201
+            "\033[38;5;196m[Auth] ⚠️  WARNING: JWT_SECRET_KEY is the insecure default value. "
+            "Anyone can forge tokens. Set JWT_SECRET_KEY in .env before deploying.\033[0m",
+            flush=True,
+        )
+    if s.ADMIN_PASSWORD == "changeme":
+        print(  # noqa: T201
+            "\033[38;5;196m[Auth] ⚠️  WARNING: ADMIN_PASSWORD is 'changeme'. "
+            "Set ADMIN_PASSWORD in .env before deploying.\033[0m",
+            flush=True,
+        )
+
+
 async def _seed_admin_user() -> None:
     """Create the admin user if it doesn't already exist.
 
@@ -250,6 +267,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await load_llm_settings_on_startup(session)
     # Mark any leftover in-progress analysis tasks as failed
     await _cleanup_stale_analysis_tasks()
+    # Warn loudly if insecure defaults are still in use
+    _warn_insecure_defaults()
     # Ensure admin user exists (idempotent)
     await _seed_admin_user()
     # Start ETL scheduler for background data fetching

--- a/backend/main.py
+++ b/backend/main.py
@@ -103,6 +103,38 @@ def _print_startup_banner() -> None:
     print(banner, flush=True)  # noqa: T201 — intentional print for startup visibility
 
 
+async def _seed_admin_user() -> None:
+    """Create the admin user if it doesn't already exist.
+
+    Credentials are taken from settings (ADMIN_USERNAME / ADMIN_PASSWORD).
+    This is idempotent — re-running on every startup is safe.
+    """
+    from sqlalchemy import select
+    from auth import hash_password
+    from models.user import User
+
+    s = get_settings()
+    async with async_session_factory() as session:
+        result = await session.execute(select(User).where(User.username == s.ADMIN_USERNAME))
+        if result.scalar_one_or_none() is None:
+            user = User(
+                username=s.ADMIN_USERNAME,
+                hashed_password=hash_password(s.ADMIN_PASSWORD),
+                is_active=True,
+            )
+            session.add(user)
+            await session.commit()
+            print(  # noqa: T201
+                f"\033[38;5;39m[Auth]\033[0m Admin user '{s.ADMIN_USERNAME}' created",
+                flush=True,
+            )
+        else:
+            print(  # noqa: T201
+                f"\033[38;5;39m[Auth]\033[0m Admin user '{s.ADMIN_USERNAME}' already exists",
+                flush=True,
+            )
+
+
 async def _cleanup_stale_analysis_tasks() -> None:
     """Mark any in-progress analysis tasks as failed on startup.
 
@@ -218,6 +250,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         await load_llm_settings_on_startup(session)
     # Mark any leftover in-progress analysis tasks as failed
     await _cleanup_stale_analysis_tasks()
+    # Ensure admin user exists (idempotent)
+    await _seed_admin_user()
     # Start ETL scheduler for background data fetching
     etl_orchestrator.start()
     yield
@@ -233,11 +267,20 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# Configure CORS for frontend (allow any localhost port + Tauri desktop origins)
+# Configure CORS.
+# • In development: any localhost port + Tauri desktop origins are allowed via regex.
+# • In production: set CORS_ORIGINS (comma-separated) in .env — those origins are
+#   added as explicit allow_origins alongside the regex for local/desktop access.
 # Tauri v2 custom-protocol uses "tauri://localhost" on macOS;
 # the localhost plugin uses "http://tauri.localhost".
+_cors_origins: list[str] = (
+    [o.strip() for o in settings.CORS_ORIGINS.split(",") if o.strip()]
+    if settings.CORS_ORIGINS
+    else []
+)
 app.add_middleware(
     CORSMiddleware,
+    allow_origins=_cors_origins,
     allow_origin_regex=r"^http://(localhost|127\.0\.0\.1)(:\d+)?$|^https?://tauri\.localhost$|^tauri://localhost$",
     allow_credentials=True,
     allow_methods=["*"],

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,0 +1,24 @@
+"""User model for authentication."""
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    username: Mapped[str] = mapped_column(String(100), unique=True, index=True)
+    hashed_password: Mapped[str] = mapped_column(String(256))
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+
+    def __repr__(self) -> str:
+        return f"<User(username={self.username!r})>"

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,11 +1,15 @@
 """User model for authentication."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import Boolean, String
 from sqlalchemy.orm import Mapped, mapped_column
 
 from database import Base
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
 
 
 class User(Base):
@@ -15,10 +19,8 @@ class User(Base):
     username: Mapped[str] = mapped_column(String(100), unique=True, index=True)
     hashed_password: Mapped[str] = mapped_column(String(256))
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
-    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
-    updated_at: Mapped[datetime] = mapped_column(
-        default=datetime.utcnow, onupdate=datetime.utcnow
-    )
+    created_at: Mapped[datetime] = mapped_column(default=_now)
+    updated_at: Mapped[datetime] = mapped_column(default=_now, onupdate=_now)
 
     def __repr__(self) -> str:
         return f"<User(username={self.username!r})>"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "tradingview-ta>=3.3.0",
     "uvicorn[standard]",
     "yfinance",
+    "python-jose[cryptography]>=3.3.0",
+    "passlib[bcrypt]>=1.7.4",
 ]
 
 [project.optional-dependencies]

--- a/backend/schemas/auth.py
+++ b/backend/schemas/auth.py
@@ -1,0 +1,18 @@
+"""Auth request/response schemas."""
+
+from pydantic import BaseModel
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class TokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+class UserResponse(BaseModel):
+    username: str
+    is_active: bool

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -6,6 +6,8 @@ import { Providers } from '@/lib/providers';
 import { Header } from '@/components/layout/header';
 import { Sidebar } from '@/components/layout/sidebar';
 import { BackendReadinessGate } from '@/components/backend-readiness-gate';
+import { AuthProvider } from '@/contexts/auth-context';
+import { AuthGate } from '@/components/auth-gate';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -39,15 +41,19 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <Providers>
-            <BackendReadinessGate>
-              <div className="relative flex min-h-screen flex-col">
-                <Header />
-                <div className="flex flex-1">
-                  <Sidebar />
-                  <main className="flex-1 p-6">{children}</main>
-                </div>
-              </div>
-            </BackendReadinessGate>
+            <AuthProvider>
+              <BackendReadinessGate>
+                <AuthGate>
+                  <div className="relative flex min-h-screen flex-col">
+                    <Header />
+                    <div className="flex flex-1">
+                      <Sidebar />
+                      <main className="flex-1 p-6">{children}</main>
+                    </div>
+                  </div>
+                </AuthGate>
+              </BackendReadinessGate>
+            </AuthProvider>
           </Providers>
         </ThemeProvider>
       </body>

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { TrendingUp, Lock, User } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { useAuth } from '@/contexts/auth-context';
+
+export default function LoginPage() {
+  const { login } = useAuth();
+  const router = useRouter();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      await login(username, password);
+      router.push('/');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 via-indigo-50 to-slate-100 dark:from-slate-950 dark:via-purple-950 dark:to-slate-950">
+      <Card className="w-full max-w-sm shadow-xl">
+        <CardHeader className="text-center space-y-3">
+          <div className="flex justify-center">
+            <div className="rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 p-3">
+              <TrendingUp className="h-6 w-6 text-white" />
+            </div>
+          </div>
+          <CardTitle className="text-2xl font-bold bg-gradient-to-r from-indigo-600 to-purple-600 bg-clip-text text-transparent">
+            Teletraan
+          </CardTitle>
+          <CardDescription>AI-Powered Market Intelligence</CardDescription>
+        </CardHeader>
+
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="username">Username</Label>
+              <div className="relative">
+                <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="username"
+                  type="text"
+                  autoComplete="username"
+                  className="pl-9"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  required
+                />
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="password">Password</Label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                <Input
+                  id="password"
+                  type="password"
+                  autoComplete="current-password"
+                  className="pl-9"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  required
+                />
+              </div>
+            </div>
+
+            {error && (
+              <p className="text-sm text-destructive text-center">{error}</p>
+            )}
+
+            <Button type="submit" className="w-full" disabled={loading}>
+              {loading ? 'Signing in…' : 'Sign in'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/components/auth-gate.tsx
+++ b/frontend/components/auth-gate.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { usePathname, useRouter } from 'next/navigation';
+import { useEffect, type ReactNode } from 'react';
+import { useAuth } from '@/contexts/auth-context';
+import { TrendingUp } from 'lucide-react';
+
+/**
+ * Renders children only when the user is authenticated.
+ * Redirects to /login otherwise. The /login path itself is always rendered.
+ */
+export function AuthGate({ children }: { children: ReactNode }) {
+  const { user, isLoading } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const isLoginPage = pathname === '/login';
+
+  useEffect(() => {
+    if (!isLoading && !user && !isLoginPage) {
+      router.replace('/login');
+    }
+    if (!isLoading && user && isLoginPage) {
+      router.replace('/');
+    }
+  }, [isLoading, user, isLoginPage, router]);
+
+  // While checking session — show minimal spinner
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-50 via-indigo-50 to-slate-100 dark:from-slate-950 dark:via-purple-950 dark:to-slate-950">
+        <div className="flex flex-col items-center gap-4 text-muted-foreground">
+          <div className="rounded-full bg-gradient-to-br from-indigo-500 to-purple-600 p-4 animate-pulse">
+            <TrendingUp className="h-7 w-7 text-white" />
+          </div>
+          <p className="text-sm">Loading…</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Login page: always render (redirect away handled in useEffect above)
+  if (isLoginPage) return <>{children}</>;
+
+  // Not authenticated: render nothing (redirect in progress)
+  if (!user) return null;
+
+  return <>{children}</>;
+}

--- a/frontend/components/layout/header.tsx
+++ b/frontend/components/layout/header.tsx
@@ -48,6 +48,7 @@ import { Separator } from '@/components/ui/separator';
 import { ThemeToggle } from '@/components/theme-toggle';
 import { cn } from '@/lib/utils';
 import { useDeepInsights } from '@/lib/hooks/use-deep-insights';
+import { useAuth } from '@/contexts/auth-context';
 
 // Mirror sidebar navigation for mobile menu
 const primaryNavItems = [
@@ -69,6 +70,7 @@ const secondaryNavItems = [
 export function Header() {
   const pathname = usePathname();
   const [dataExpanded, setDataExpanded] = useState(false);
+  const { user, logout } = useAuth();
 
   // Fetch insights for mobile menu badges
   const { data: insightsData } = useDeepInsights({ limit: 100 });
@@ -236,16 +238,23 @@ export function Header() {
               <Button variant="ghost" size="icon" className="rounded-full hover:bg-slate-100 dark:hover:bg-white/10">
                 <Avatar className="h-7 w-7 ring-1 ring-slate-200 dark:ring-white/20">
                   <AvatarFallback className="bg-gradient-to-br from-indigo-500 to-purple-500 dark:from-cyan-500 dark:to-purple-500 text-white text-xs font-medium">
-                    U
+                    {user?.username?.[0]?.toUpperCase() ?? 'U'}
                   </AvatarFallback>
                 </Avatar>
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuLabel>My Account</DropdownMenuLabel>
+              <DropdownMenuLabel>{user?.username ?? 'My Account'}</DropdownMenuLabel>
               <DropdownMenuSeparator />
               <DropdownMenuItem asChild>
                 <Link href="/settings">Settings</Link>
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                className="text-destructive focus:text-destructive"
+                onClick={() => logout()}
+              >
+                Sign out
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>

--- a/frontend/contexts/auth-context.tsx
+++ b/frontend/contexts/auth-context.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import { setAccessToken } from '@/lib/auth-store';
+
+const API_URL = (process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000').replace(/\/api\/v1\/?$/, '');
+
+// Access tokens are 15 min; refresh 2 min early.
+const REFRESH_INTERVAL_MS = 13 * 60 * 1000;
+
+interface AuthUser {
+  username: string;
+  is_active: boolean;
+}
+
+interface AuthContextValue {
+  user: AuthUser | null;
+  isLoading: boolean;
+  login: (username: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const scheduleRefresh = useCallback(() => {
+    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+    refreshTimerRef.current = setTimeout(async () => {
+      try {
+        const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+          method: 'POST',
+          credentials: 'include',
+        });
+        if (res.ok) {
+          const data = await res.json();
+          setAccessToken(data.access_token);
+          scheduleRefresh();
+        } else {
+          // Refresh failed — clear session
+          setAccessToken(null);
+          setUser(null);
+        }
+      } catch {
+        setAccessToken(null);
+        setUser(null);
+      }
+    }, REFRESH_INTERVAL_MS);
+  }, []);
+
+  // On mount: try to restore session via the httpOnly refresh cookie
+  useEffect(() => {
+    async function restoreSession() {
+      try {
+        // First refresh to get a fresh access token
+        const refreshRes = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+          method: 'POST',
+          credentials: 'include',
+        });
+        if (!refreshRes.ok) {
+          setIsLoading(false);
+          return;
+        }
+        const refreshData = await refreshRes.json();
+        setAccessToken(refreshData.access_token);
+
+        // Then fetch user info
+        const meRes = await fetch(`${API_URL}/api/v1/auth/me`, {
+          credentials: 'include',
+        });
+        if (meRes.ok) {
+          const userData: AuthUser = await meRes.json();
+          setUser(userData);
+          scheduleRefresh();
+        }
+      } catch {
+        // Network error or no session — stay logged out
+      } finally {
+        setIsLoading(false);
+      }
+    }
+    restoreSession();
+
+    return () => {
+      if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+    };
+  }, [scheduleRefresh]);
+
+  const login = useCallback(async (username: string, password: string) => {
+    const res = await fetch(`${API_URL}/api/v1/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ username, password }),
+    });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new Error(body?.detail || 'Login failed');
+    }
+    const data = await res.json();
+    setAccessToken(data.access_token);
+
+    const meRes = await fetch(`${API_URL}/api/v1/auth/me`, {
+      credentials: 'include',
+    });
+    if (meRes.ok) {
+      const userData: AuthUser = await meRes.json();
+      setUser(userData);
+      scheduleRefresh();
+    }
+  }, [scheduleRefresh]);
+
+  const logout = useCallback(async () => {
+    try {
+      await fetch(`${API_URL}/api/v1/auth/logout`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+    } catch {
+      // Best-effort
+    }
+    if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
+    setAccessToken(null);
+    setUser(null);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, isLoading, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used inside <AuthProvider>');
+  return ctx;
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -9,6 +9,27 @@ export class ApiError extends Error {
   }
 }
 
+// Try to refresh the access token using the httpOnly refresh cookie.
+// Returns the new token on success, null on failure.
+async function _tryRefresh(): Promise<string | null> {
+  try {
+    const { setAccessToken } = await import('@/lib/auth-store');
+    const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      setAccessToken(null);
+      return null;
+    }
+    const data = await res.json();
+    setAccessToken(data.access_token);
+    return data.access_token as string;
+  } catch {
+    return null;
+  }
+}
+
 // Generic fetch function with query params support
 export async function fetchApi<T>(
   endpoint: string,
@@ -32,13 +53,47 @@ export async function fetchApi<T>(
 
   const { params: _params, ...fetchOptions } = options || {};
 
+  // Inject Bearer token if available
+  const { getAccessToken } = await import('@/lib/auth-store');
+  const token = getAccessToken();
+  const authHeader: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
+
   const res = await fetch(url, {
     ...fetchOptions,
+    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
+      ...authHeader,
       ...fetchOptions?.headers,
     },
   });
+
+  // On 401, attempt a token refresh and retry once
+  if (res.status === 401) {
+    const newToken = await _tryRefresh();
+    if (newToken) {
+      const retryAuthHeader = { Authorization: `Bearer ${newToken}` };
+      const retryRes = await fetch(url, {
+        ...fetchOptions,
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          ...retryAuthHeader,
+          ...fetchOptions?.headers,
+        },
+      });
+      if (!retryRes.ok) {
+        const errorBody = await retryRes.text();
+        throw new ApiError(retryRes.status, errorBody || retryRes.statusText);
+      }
+      return retryRes.json();
+    }
+    // Refresh failed — redirect to login
+    if (typeof window !== 'undefined' && !window.location.pathname.startsWith('/login')) {
+      window.location.href = '/login';
+    }
+    throw new ApiError(401, 'Session expired. Please log in again.');
+  }
 
   if (!res.ok) {
     const errorBody = await res.text();

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -2,6 +2,9 @@
 const rawUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
 const API_URL = rawUrl.replace(/\/api\/v1\/?$/, '');
 
+// Static import — avoids async overhead on every API call
+import { getAccessToken, setAccessToken } from '@/lib/auth-store';
+
 export class ApiError extends Error {
   constructor(public status: number, message: string) {
     super(message);
@@ -9,11 +12,12 @@ export class ApiError extends Error {
   }
 }
 
-// Try to refresh the access token using the httpOnly refresh cookie.
-// Returns the new token on success, null on failure.
-async function _tryRefresh(): Promise<string | null> {
+// Singleton promise — prevents concurrent 401s from triggering multiple refreshes.
+// On page load with N parallel queries all returning 401, only one refresh is issued.
+let _refreshPromise: Promise<string | null> | null = null;
+
+async function _doRefresh(): Promise<string | null> {
   try {
-    const { setAccessToken } = await import('@/lib/auth-store');
     const res = await fetch(`${API_URL}/api/v1/auth/refresh`, {
       method: 'POST',
       credentials: 'include',
@@ -28,6 +32,15 @@ async function _tryRefresh(): Promise<string | null> {
   } catch {
     return null;
   }
+}
+
+function _tryRefresh(): Promise<string | null> {
+  if (!_refreshPromise) {
+    _refreshPromise = _doRefresh().finally(() => {
+      _refreshPromise = null;
+    });
+  }
+  return _refreshPromise;
 }
 
 // Generic fetch function with query params support
@@ -54,7 +67,6 @@ export async function fetchApi<T>(
   const { params: _params, ...fetchOptions } = options || {};
 
   // Inject Bearer token if available
-  const { getAccessToken } = await import('@/lib/auth-store');
   const token = getAccessToken();
   const authHeader: Record<string, string> = token ? { Authorization: `Bearer ${token}` } : {};
 

--- a/frontend/lib/auth-store.ts
+++ b/frontend/lib/auth-store.ts
@@ -1,0 +1,17 @@
+/**
+ * In-memory access token store.
+ *
+ * The access token lives only in JS memory — never in localStorage or a cookie —
+ * so it is invisible to XSS attacks. The companion refresh token is stored in an
+ * httpOnly cookie managed entirely by the browser.
+ */
+
+let _accessToken: string | null = null;
+
+export function getAccessToken(): string | null {
+  return _accessToken;
+}
+
+export function setAccessToken(token: string | null): void {
+  _accessToken = token;
+}


### PR DESCRIPTION
## Summary

Closes #33. Full JWT-based authentication, protecting every API route and every frontend page.

**Backend**
- `auth/` module: access tokens (15 min) + refresh tokens (7 days httpOnly cookie) via `python-jose` + bcrypt
- `models/user.py`: `User` ORM model (username, hashed_password, is_active)
- `api/routes/auth.py`: `POST /auth/login`, `POST /auth/refresh`, `GET /auth/me`, `POST /auth/logout`
- `api/deps.py`: `get_current_user` — validates Bearer token, raises 401 on failure
- `api/routes/__init__.py`: all routes protected via router-level `dependencies=[Depends(get_current_user)]`; health + auth routes are public
- `main.py`: seeds admin user on startup (idempotent); `CORS_ORIGINS` env var for production deployments
- `config.py`: `JWT_SECRET_KEY`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`, `CORS_ORIGINS` settings

**Frontend**
- `contexts/auth-context.tsx`: `AuthProvider` — restores session via refresh cookie on mount, schedules token refresh every 13 min
- `lib/auth-store.ts`: in-memory access token store (never touches localStorage or cookies — XSS-safe)
- `lib/api.ts`: injects `Authorization: Bearer` header; on 401 auto-refreshes and retries once, then redirects to `/login`
- `app/login/page.tsx`: clean login form
- `components/auth-gate.tsx`: redirects unauthenticated users to `/login`
- `app/layout.tsx`: wrapped with `AuthProvider` + `AuthGate`
- `components/layout/header.tsx`: shows username in avatar, Logout in dropdown

## Deployment

Set these in `backend/.env` before deploying:
```
JWT_SECRET_KEY=<run: python3 -c "import secrets; print(secrets.token_hex(32))">
ADMIN_USERNAME=<your-username>
ADMIN_PASSWORD=<your-password>
CORS_ORIGINS=https://your-domain.com
```

## Test plan
- [ ] Start backend — admin user seeded on first launch
- [ ] Open app — redirects to `/login`
- [ ] Login with admin credentials — redirects to dashboard
- [ ] All API calls include Bearer header
- [ ] Page refresh — session restored from refresh cookie
- [ ] Wait 13 min (or force-expire token) — token silently refreshed
- [ ] Sign out — cookie cleared, redirected to login
- [ ] Direct API call without token → 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)