### PR TITLE
feat: configurable research policy + best_bets mode for autonomous discovery

### DIFF
--- a/backend/analysis/agents/synthesis_lead.py
+++ b/backend/analysis/agents/synthesis_lead.py
@@ -971,6 +971,7 @@ def parse_synthesis_response_full(response: str) -> SynthesisParseResult:
             "primary_symbol": insight.get("primary_symbol"),
             "related_symbols": insight.get("related_symbols", []),
             "secondary_plays": insight.get("secondary_plays"),
+            "tier": insight.get("tier"),
             "supporting_evidence": insight.get("supporting_evidence", []),
             "confidence": float(insight.get("confidence", 0.5)),
             "time_horizon": insight.get("time_horizon", "medium_term"),

--- a/backend/analysis/autonomous_engine.py
+++ b/backend/analysis/autonomous_engine.py
@@ -444,6 +444,43 @@ class AutonomousDeepEngine:
         self._stock_clusters: list[dict[str, Any]] = []
         self._cluster_analyses: list[dict[str, Any]] = []
 
+    def _synthesis_count_guidance(
+        self, symbols_count: int, max_insights: int
+    ) -> tuple[str, str]:
+        """Build the (target_line, count_line) for the synthesis context.
+
+        Two regimes, selected by the active policy:
+        - Concentrated (``max_total_insights`` set, e.g. best_bets): a hard
+          ceiling — rank the analyzed field and return only the top N, fewer
+          allowed, never pad.
+        - Default: a floor — don't collapse to one pick despite the
+          technical/sector/risk-only analyst panel.
+        """
+        if self._policy.max_total_insights:
+            target = f"### Target: Select the TOP {max_insights} name(s) from the {symbols_count} analyzed"
+            count = (
+                f"CONCENTRATED OUTPUT: rank all {symbols_count} deep-dived names by expected "
+                f"payoff over the holding window and return ONLY the best {max_insights}, "
+                "ordered best-first in the insights array. Returning fewer is fine if only "
+                "fewer truly stand out — never pad to hit the number. Ranking and quality "
+                "beat coverage."
+            )
+            return target, count
+
+        insight_floor = (
+            min(max_insights, max(3, symbols_count // 2)) if symbols_count else max_insights
+        )
+        target = f"### Target: Generate {max_insights} actionable insights"
+        count = (
+            f"Hard floor: produce AT LEAST {insight_floor} distinct insights. "
+            f"{symbols_count} symbols received full deep-dive coverage, so do NOT "
+            "collapse to a single pick. This engine runs technical/sector/risk "
+            "analysts by design — the absence of a macro or correlation report is "
+            "NOT a coverage gap and is NOT a reason to withhold insights or lower "
+            "conviction."
+        )
+        return target, count
+
     def _normalize_tier(self, raw: Any) -> str | None:
         """Map a synthesis-provided tier onto the active policy's tier names.
 
@@ -997,10 +1034,16 @@ class AutonomousDeepEngine:
         # env default preset. Failure must never break the run.
         self._policy = await self._resolve_research_policy(policy)
         result.research_policy = self._policy.model_dump()
+        # A concentrated policy (e.g. best_bets) caps the final insight count while
+        # still deep-diving a wide field, so synthesis can rank and return only the
+        # top N. Clamp here; deep_dive_count is intentionally left untouched.
+        if self._policy.max_total_insights:
+            max_insights = min(max_insights, self._policy.max_total_insights)
         logger.info(
-            "Research policy: %s (objective=%s, conviction=%s, min_rr=%.1f)",
+            "Research policy: %s (objective=%s, conviction=%s, min_rr=%.1f, cap=%s) -> max_insights=%d",
             self._policy.name, self._policy.objective,
             self._policy.conviction_model, self._policy.min_reward_risk,
+            self._policy.max_total_insights, max_insights,
         )
 
         # Clear activity log for new run, scoped to this task_id
@@ -2706,19 +2749,14 @@ class AutonomousDeepEngine:
                     lines.append(f"  Conviction: {analysis['conviction']}")
 
         symbols_count = len(analyst_reports)
-        insight_floor = min(max_insights, max(3, symbols_count // 2)) if symbols_count else max_insights
+        target_line, count_line = self._synthesis_count_guidance(symbols_count, max_insights)
 
         lines.extend([
             "",
             f"Symbols Analyzed ({symbols_count}): {', '.join(analyst_reports.keys())}",
             "",
-            f"### Target: Generate {max_insights} actionable insights",
-            f"Hard floor: produce AT LEAST {insight_floor} distinct insights. "
-            f"{symbols_count} symbols received full deep-dive coverage, so do NOT "
-            "collapse to a single pick. This engine runs technical/sector/risk "
-            "analysts by design — the absence of a macro or correlation report is "
-            "NOT a coverage gap and is NOT a reason to withhold insights or lower "
-            "conviction.",
+            target_line,
+            count_line,
             "Prioritize opportunities with:",
             "- Strong macro/heatmap alignment",
             "- Thematic connections between stocks",
@@ -4044,20 +4082,15 @@ class AutonomousDeepEngine:
             lines.append(f"- {sector.sector_name}: {sector.rationale[:80]}...")
 
         symbols_count = len(analyst_reports)
-        insight_floor = min(max_insights, max(3, symbols_count // 2)) if symbols_count else max_insights
+        target_line, count_line = self._synthesis_count_guidance(symbols_count, max_insights)
 
         lines.extend([
             "",
             f"### Candidates Screened: {candidates.total_screened}",
             f"Symbols Analyzed ({symbols_count}): {', '.join(analyst_reports.keys())}",
             "",
-            f"### Target: Generate {max_insights} actionable insights",
-            f"Hard floor: produce AT LEAST {insight_floor} distinct insights. "
-            f"{symbols_count} symbols received full deep-dive coverage, so do NOT "
-            "collapse to a single pick. This engine runs technical/sector/risk "
-            "analysts by design — the absence of a macro or correlation report is "
-            "NOT a coverage gap and is NOT a reason to withhold insights or lower "
-            "conviction.",
+            target_line,
+            count_line,
             "Prioritize opportunities with:",
             "- Strong macro/sector alignment",
             "- Multiple analyst agreement",

--- a/backend/analysis/autonomous_engine.py
+++ b/backend/analysis/autonomous_engine.py
@@ -181,6 +181,26 @@ def _clip(value: Any, max_len: int) -> str | None:
     return text[:max_len]
 
 
+def _parse_price_level(value: Any) -> float | None:
+    """Extract the first dollar figure from a free-text price field.
+
+    Synthesis emits levels like ``"$270 (28% upside)"`` or ``"$140 (below
+    support)"`` or a range ``"$880-900"``. Return the first numeric price, or
+    None when there is no parseable figure (e.g. ``"N/A - bearish"``).
+    """
+    if value is None:
+        return None
+    import re
+
+    m = re.search(r"\$?\s*([0-9][0-9,]*(?:\.[0-9]+)?)", str(value))
+    if not m:
+        return None
+    try:
+        return float(m.group(1).replace(",", ""))
+    except ValueError:
+        return None
+
+
 @dataclass
 class AutonomousAnalysisResult:
     """Complete result from autonomous analysis pipeline."""
@@ -438,6 +458,7 @@ class AutonomousDeepEngine:
         self._sentiment_data: dict | None = None  # Reddit social sentiment
         self._news_data: dict | None = None  # Financial-news sentiment intelligence
         self._macro_news_data: dict | None = None  # Macro-economic news for the regime scan
+        self._live_prices: dict[str, float] = {}  # Live quotes for analyzed symbols (synthesis-time)
 
         # Stock thematic descriptions (populated during Phase 3.5)
         self._stock_descriptions: dict[str, str] = {}
@@ -499,6 +520,109 @@ class AutonomousDeepEngine:
         except Exception:
             pass
         return text
+
+    async def _fetch_live_prices(self, symbols: list[str]) -> dict[str, float]:
+        """Fetch fresh live prices for the given symbols (best-effort).
+
+        The deep-dive context reads price_history from the DB, which can be
+        stale (the ETL ingestion may be days/weeks behind). Synthesis targets
+        and the upside % are only trustworthy when anchored on the real current
+        price, so we pull live quotes here. Returns {SYMBOL: price}; missing or
+        failed symbols are simply absent. Never raises.
+        """
+        uniq = list(dict.fromkeys(s.upper().strip() for s in (symbols or []) if s and s.strip()))
+        if not uniq:
+            return {}
+        try:
+            from data.adapters.yahoo import YahooFinanceAdapter  # type: ignore[import-not-found]
+
+            adapter = YahooFinanceAdapter()
+            quotes = await adapter.get_multiple_prices(uniq)
+            prices: dict[str, float] = {}
+            for sym, data in (quotes or {}).items():
+                if isinstance(data, dict) and not data.get("error"):
+                    px = data.get("price")
+                    if isinstance(px, (int, float)) and px > 0:
+                        prices[sym.upper()] = float(px)
+            logger.info("[AUTO] Live prices fetched for %d/%d symbols", len(prices), len(uniq))
+            return prices
+        except Exception as e:
+            logger.warning("[AUTO] Live price fetch failed (non-fatal): %s", e)
+            return {}
+
+    def _format_live_prices_context(self, prices: dict[str, float]) -> str:
+        """Render a live-price block so synthesis anchors targets on real prices."""
+        if not prices:
+            return ""
+        lines = [
+            "## Live Current Prices (fetched now — AUTHORITATIVE)",
+            "Anchor every entry/target/stop and the upside % to THESE prices, not to "
+            "any price in the analyst reports (which may be stale). Compute upside as "
+            "(target - current) / current.",
+        ]
+        for sym, px in sorted(prices.items()):
+            lines.append(f"- {sym}: ${px:g}")
+        return "\n".join(lines)
+
+    def _verify_insight_economics(
+        self, insights: list[dict[str, Any]], prices: dict[str, float]
+    ) -> list[dict[str, Any]]:
+        """Recompute upside / R:R from live prices; relabel, gate, and rank.
+
+        Synthesis states an upside % in free text, which can be wrong or anchored
+        to a hallucinated price (e.g. a $215 target on SE labeled "+35%" when SE
+        trades ~$91). We recompute the real upside from the live price + the parsed
+        target, rewrite the displayed levels honestly, and — for concentrated
+        policies (best_bets) — drop picks whose verified upside is below the policy
+        floor or implausibly large (a sign of a bad target), then rank best-first.
+        """
+        if not insights:
+            return insights
+        floor = float(self._policy.target_upside_pct or 0)
+        concentrated = bool(self._policy.max_total_insights)
+        # A "best bet" upside far above what the holding window can plausibly
+        # deliver signals a mis-anchored target (e.g. a $215 SE target while SE
+        # trades ~$91). Cap tighter for short-horizon modes.
+        implausible_cap = 80.0 if self._policy.time_horizon_bias == "short_term" else 150.0
+        kept: list[dict[str, Any]] = []
+        for ins in insights:
+            sym = (ins.get("primary_symbol") or "").upper().strip()
+            price = prices.get(sym)
+            target = _parse_price_level(ins.get("target_price") or ins.get("target"))
+            stop = _parse_price_level(ins.get("stop_loss") or ins.get("stop"))
+            upside = None
+            if price and target and price > 0:
+                upside = (target - price) / price * 100.0
+                ins["_verified_upside_pct"] = round(upside, 1)
+                ins["_live_price"] = price
+                disp = f"${target:g} (live ${price:g} → {upside:+.0f}%)"
+                rr = None
+                if stop and stop > 0 and price > stop:
+                    downside = (price - stop) / price * 100.0
+                    if downside > 0:
+                        rr = upside / downside
+                        ins["_verified_rr"] = round(rr, 2)
+                ins["target_price"] = disp[:50]
+                # Gate only when we have a verified number and a concentrated mandate.
+                if concentrated:
+                    if upside < max(0.0, floor * 0.6):
+                        logger.info(
+                            "[AUTO] Dropping %s: verified upside %.0f%% below floor (%.0f%%)",
+                            sym, upside, floor,
+                        )
+                        continue
+                    if upside > implausible_cap:
+                        logger.info(
+                            "[AUTO] Dropping %s: verified upside %.0f%% implausible "
+                            "for %s window (target likely mis-anchored)",
+                            sym, upside, self._policy.time_horizon_bias,
+                        )
+                        continue
+            kept.append(ins)
+        # Rank best-first by verified upside when the policy ranks on payoff.
+        if self._policy.conviction_model in ("payoff_weighted", "barbell") or concentrated:
+            kept.sort(key=lambda i: i.get("_verified_upside_pct", -1e9), reverse=True)
+        return kept
 
     async def _resolve_research_policy(self, override: "str | dict | None"):
         """Resolve the effective research policy for this run.
@@ -2609,9 +2733,16 @@ class AutonomousDeepEngine:
         # deep-dive candidates + the Phase-1 Reddit sentiment capture).
         news_sentiment_context = await self._build_news_and_sentiment_context(symbols)
 
+        # Live prices for ALL analyzed symbols so synthesis anchors targets and
+        # the upside % on today's price rather than the (possibly stale) DB history.
+        self._live_prices = await self._fetch_live_prices(list(analyst_reports.keys()))
+        live_price_block = self._format_live_prices_context(self._live_prices)
+        live_price_section = f"\n\n{live_price_block}" if live_price_block else ""
+
         full_context = (
             f"{autonomous_context}{portfolio_context}{thematic_context}"
             f"{investor_context}{quant_context_block}{news_sentiment_context}"
+            f"{live_price_section}"
             f"\n\n{synthesis_context}"
         )
 
@@ -2633,6 +2764,9 @@ class AutonomousDeepEngine:
 
         insights = self._dedupe_insights(insights)
         insights = self._enforce_portfolio_action_rules(insights, portfolio_holdings)
+        # Recompute upside/R:R from live prices: relabel honestly, gate out
+        # sub-floor / mis-anchored picks (concentrated policies), rank best-first.
+        insights = self._verify_insight_economics(insights, getattr(self, "_live_prices", {}) or {})
 
         # Adjust confidence based on historical track record
         try:
@@ -3978,9 +4112,14 @@ class AutonomousDeepEngine:
             legacy_candidate_symbols
         )
 
+        # Live prices so synthesis anchors targets on today's price, not stale history.
+        self._live_prices = await self._fetch_live_prices(list(analyst_reports.keys()))
+        live_price_block = self._format_live_prices_context(self._live_prices)
+        live_price_section = f"\n\n{live_price_block}" if live_price_block else ""
+
         full_context = (
             f"{autonomous_context}{portfolio_context}"
-            f"{news_sentiment_context}\n\n{synthesis_context}"
+            f"{news_sentiment_context}{live_price_section}\n\n{synthesis_context}"
         )
 
         # Query LLM
@@ -4001,6 +4140,9 @@ class AutonomousDeepEngine:
 
         insights = self._dedupe_insights(insights)
         insights = self._enforce_portfolio_action_rules(insights, portfolio_holdings)
+        # Recompute upside/R:R from live prices: relabel honestly, gate out
+        # sub-floor / mis-anchored picks (concentrated policies), rank best-first.
+        insights = self._verify_insight_economics(insights, getattr(self, "_live_prices", {}) or {})
 
         # Adjust confidence based on historical track record
         try:

--- a/backend/analysis/autonomous_engine.py
+++ b/backend/analysis/autonomous_engine.py
@@ -171,6 +171,16 @@ VALID_INSIGHT_TYPES = {t.value for t in InsightType}
 VALID_ACTIONS = {a.value for a in InsightAction}
 
 
+def _clip(value: Any, max_len: int) -> str | None:
+    """Coerce to a trimmed string capped at max_len, or None when empty."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:max_len]
+
+
 @dataclass
 class AutonomousAnalysisResult:
     """Complete result from autonomous analysis pipeline."""
@@ -194,6 +204,7 @@ class AutonomousAnalysisResult:
     factor_scores: dict[str, Any] = field(default_factory=dict)
     correlation_highlights: dict[str, Any] = field(default_factory=dict)
     catalyst_data: list[dict[str, Any]] = field(default_factory=list)
+    research_policy: dict[str, Any] = field(default_factory=dict)
     thematic_analysis: dict[str, Any] = field(default_factory=dict)
     investor_intelligence: dict[str, Any] = field(default_factory=dict)
 
@@ -399,6 +410,11 @@ class AutonomousDeepEngine:
         # Per-run metrics accumulator (set at the start of each analysis run)
         self._run_metrics: RunMetrics | None = None
 
+        # Resolved research policy for the current run (objective function).
+        # Set per-run in run_autonomous_analysis; defaults to the balanced preset.
+        from analysis.research_policy import get_preset  # type: ignore[import-not-found]
+        self._policy = get_preset(None)
+
         # Activity log for live LLM tracking (scoped per task_id)
         self._activity_log: list[LLMActivityEntry] = []
         self._activity_seq: int = 0
@@ -427,6 +443,61 @@ class AutonomousDeepEngine:
         self._stock_descriptions: dict[str, str] = {}
         self._stock_clusters: list[dict[str, Any]] = []
         self._cluster_analyses: list[dict[str, Any]] = []
+
+    def _normalize_tier(self, raw: Any) -> str | None:
+        """Map a synthesis-provided tier onto the active policy's tier names.
+
+        Returns the canonical tier name when it matches a policy tier (case- and
+        separator-insensitive), otherwise the trimmed raw value (still useful for
+        display), or None. Never raises.
+        """
+        text = _clip(raw, 40)
+        if not text:
+            return None
+        try:
+            key = text.lower().replace(" ", "_").replace("-", "_")
+            for name in self._policy.tier_names():
+                if name.lower() == key:
+                    return name
+        except Exception:
+            pass
+        return text
+
+    async def _resolve_research_policy(self, override: "str | dict | None"):
+        """Resolve the effective research policy for this run.
+
+        Precedence: per-run ``override`` -> active policy stored in
+        ``user_settings['research_policy']`` -> env ``RESEARCH_POLICY_DEFAULT``
+        preset. Any failure falls back to the built-in default preset so a
+        misconfigured policy can never break the pipeline.
+        """
+        from analysis.research_policy import build_policy, get_preset  # type: ignore[import-not-found]
+
+        env_default = None
+        try:
+            from config import get_settings  # type: ignore[import-not-found]
+            env_default = getattr(get_settings(), "RESEARCH_POLICY_DEFAULT", None)
+        except Exception as cfg_err:
+            logger.debug("Could not read RESEARCH_POLICY_DEFAULT: %s", cfg_err)
+
+        active_setting = None
+        try:
+            from services.settings import get_settings_service  # type: ignore[import-not-found]
+            async with async_session_factory() as session:
+                svc = get_settings_service(session)
+                active_setting = await svc.get_setting("research_policy")
+        except Exception as set_err:
+            logger.debug("Could not read active research_policy setting: %s", set_err)
+
+        try:
+            return build_policy(
+                override=override,
+                active_setting=active_setting,
+                env_default=env_default,
+            )
+        except Exception as build_err:
+            logger.warning("Failed to build research policy (using default): %s", build_err)
+            return get_preset(env_default)
 
     async def _get_portfolio_holdings(self) -> dict[str, dict[str, float]]:
         """Fetch portfolio holdings from the database.
@@ -891,6 +962,7 @@ class AutonomousDeepEngine:
         deep_dive_count: int = 12,
         task_id: str | None = None,
         quant_context: str | None = None,
+        policy: "str | dict | None" = None,
     ) -> AutonomousAnalysisResult:
         """Run complete autonomous analysis pipeline.
 
@@ -919,6 +991,17 @@ class AutonomousDeepEngine:
 
         # Store quant context for injection into analyst and synthesis contexts
         self._quant_context = quant_context
+
+        # Resolve the research policy (objective function) for this run.
+        # Precedence: per-run override -> active policy in user_settings ->
+        # env default preset. Failure must never break the run.
+        self._policy = await self._resolve_research_policy(policy)
+        result.research_policy = self._policy.model_dump()
+        logger.info(
+            "Research policy: %s (objective=%s, conviction=%s, min_rr=%.1f)",
+            self._policy.name, self._policy.objective,
+            self._policy.conviction_model, self._policy.min_reward_risk,
+        )
 
         # Clear activity log for new run, scoped to this task_id
         self.clear_activity_log(task_id=task_id)
@@ -1619,10 +1702,19 @@ class AutonomousDeepEngine:
             macro_context_dict,
         )
 
+        # Inject the research-policy mandate so stock selection is steered by the
+        # active objective (e.g. hunt asymmetric upside vs. defensive quality).
+        from analysis.research_policy import render_policy_directives  # type: ignore[import-not-found]
+        selection_directive = render_policy_directives(self._policy, "selection")
+        user_prompt = (
+            "Analyze the heatmap data and select stocks for deep dive.\n\n"
+            f"{selection_directive}"
+        )
+
         # Query LLM — the formatted_context IS the full prompt (system+context merged)
         response = await self._query_llm(
             formatted_context,
-            "Analyze the heatmap data and select stocks for deep dive.",
+            user_prompt,
             "heatmap_analyzer",
             "heatmap_analysis",
         )
@@ -2544,7 +2636,11 @@ class AutonomousDeepEngine:
         Returns:
             Formatted autonomous context string.
         """
+        from analysis.research_policy import render_policy_directives  # type: ignore[import-not-found]
+
         lines = [
+            render_policy_directives(self._policy, "synthesis"),
+            "",
             "## AUTONOMOUS DISCOVERY CONTEXT (Heatmap-Driven)",
             "",
             f"### Market Regime: {macro_context.market_regime}",
@@ -2609,11 +2705,20 @@ class AutonomousDeepEngine:
                 if analysis.get("conviction"):
                     lines.append(f"  Conviction: {analysis['conviction']}")
 
+        symbols_count = len(analyst_reports)
+        insight_floor = min(max_insights, max(3, symbols_count // 2)) if symbols_count else max_insights
+
         lines.extend([
             "",
-            f"Symbols Analyzed: {', '.join(analyst_reports.keys())}",
+            f"Symbols Analyzed ({symbols_count}): {', '.join(analyst_reports.keys())}",
             "",
             f"### Target: Generate {max_insights} actionable insights",
+            f"Hard floor: produce AT LEAST {insight_floor} distinct insights. "
+            f"{symbols_count} symbols received full deep-dive coverage, so do NOT "
+            "collapse to a single pick. This engine runs technical/sector/risk "
+            "analysts by design — the absence of a macro or correlation report is "
+            "NOT a coverage gap and is NOT a reason to withhold insights or lower "
+            "conviction.",
             "Prioritize opportunities with:",
             "- Strong macro/heatmap alignment",
             "- Thematic connections between stocks",
@@ -2857,6 +2962,10 @@ class AutonomousDeepEngine:
                     historical_precedent=data.get("historical_precedent"),
                     analysts_involved=data.get("analysts_involved", []),
                     data_sources=data_sources,
+                    entry_zone=_clip(data.get("entry_zone"), 50),
+                    target_price=_clip(data.get("target_price") or data.get("target"), 50),
+                    stop_loss=_clip(data.get("stop_loss") or data.get("stop"), 50),
+                    tier=self._normalize_tier(data.get("tier")),
                     prediction_market_data=getattr(self, '_prediction_data', None) or None,
                     sentiment_data=getattr(self, '_sentiment_data', None) or None,
                     technical_analysis_data=self._extract_ta_for_symbol(primary_symbol, pre_context) if pre_context and primary_symbol else None,
@@ -3902,7 +4011,11 @@ class AutonomousDeepEngine:
         Returns:
             Formatted autonomous context string.
         """
+        from analysis.research_policy import render_policy_directives  # type: ignore[import-not-found]
+
         lines = [
+            render_policy_directives(self._policy, "synthesis"),
+            "",
             "## AUTONOMOUS DISCOVERY CONTEXT",
             "",
             f"### Market Regime: {macro_context.market_regime}",
@@ -3930,12 +4043,21 @@ class AutonomousDeepEngine:
         for sector in sector_context.top_sectors[:3]:
             lines.append(f"- {sector.sector_name}: {sector.rationale[:80]}...")
 
+        symbols_count = len(analyst_reports)
+        insight_floor = min(max_insights, max(3, symbols_count // 2)) if symbols_count else max_insights
+
         lines.extend([
             "",
             f"### Candidates Screened: {candidates.total_screened}",
-            f"Symbols Analyzed: {', '.join(analyst_reports.keys())}",
+            f"Symbols Analyzed ({symbols_count}): {', '.join(analyst_reports.keys())}",
             "",
             f"### Target: Generate {max_insights} actionable insights",
+            f"Hard floor: produce AT LEAST {insight_floor} distinct insights. "
+            f"{symbols_count} symbols received full deep-dive coverage, so do NOT "
+            "collapse to a single pick. This engine runs technical/sector/risk "
+            "analysts by design — the absence of a macro or correlation report is "
+            "NOT a coverage gap and is NOT a reason to withhold insights or lower "
+            "conviction.",
             "Prioritize opportunities with:",
             "- Strong macro/sector alignment",
             "- Multiple analyst agreement",
@@ -4044,7 +4166,23 @@ class AutonomousDeepEngine:
                         current + report["confidence"]
                     ) / 2
 
-        return aggregated
+        # Drop analyst buckets that never ran. The autonomous engine runs only
+        # technical/sector/risk per symbol (see ANALYSTS), so the pre-seeded
+        # macro and correlation buckets stay empty at 0.0 confidence. Surfacing
+        # them makes the synthesis LLM read "0% confidence / incomplete coverage"
+        # and turn overly conservative — in one run it collapsed to a single
+        # insight, citing the empty macro/correlation reports. Only return
+        # analysts that actually produced signal (confidence or data).
+        def _has_signal(report: dict[str, Any]) -> bool:
+            if report.get("confidence", 0.0) > 0.0:
+                return True
+            return any(isinstance(v, list) and v for v in report.values())
+
+        return {
+            name: report
+            for name, report in aggregated.items()
+            if _has_signal(report)
+        }
 
     async def _store_insights(
         self,
@@ -4113,6 +4251,10 @@ class AutonomousDeepEngine:
                     historical_precedent=data.get("historical_precedent"),
                     analysts_involved=data.get("analysts_involved", []),
                     data_sources=data_sources,
+                    entry_zone=_clip(data.get("entry_zone"), 50),
+                    target_price=_clip(data.get("target_price") or data.get("target"), 50),
+                    stop_loss=_clip(data.get("stop_loss") or data.get("stop"), 50),
+                    tier=self._normalize_tier(data.get("tier")),
                     prediction_market_data=getattr(self, '_prediction_data', None) or None,
                     sentiment_data=getattr(self, '_sentiment_data', None) or None,
                     technical_analysis_data=None,  # No pre_context in legacy pipeline

--- a/backend/analysis/autonomous_runner.py
+++ b/backend/analysis/autonomous_runner.py
@@ -22,6 +22,7 @@ async def run_autonomous_analysis_pipeline(
     task_id: str,
     max_insights: int,
     deep_dive_count: int,
+    policy: "str | dict | None" = None,
 ) -> None:
     """Execute the autonomous analysis pipeline for a given task.
 
@@ -58,6 +59,7 @@ async def run_autonomous_analysis_pipeline(
             max_insights=max_insights,
             deep_dive_count=deep_dive_count,
             task_id=task_id,
+            policy=policy,
         )
 
         # Persist results
@@ -80,6 +82,9 @@ async def run_autonomous_analysis_pipeline(
                     i.id for i in analysis_result.insights
                 ]
                 task.discovery_summary = analysis_result.discovery_summary
+                if analysis_result.research_policy:
+                    import json as _json_policy
+                    task.research_policy = _json_policy.dumps(analysis_result.research_policy)
                 task.phases_completed = analysis_result.phases_completed
                 task.phase_summaries = analysis_result.phase_summaries
 

--- a/backend/analysis/research_policy.py
+++ b/backend/analysis/research_policy.py
@@ -64,6 +64,12 @@ class ResearchPolicy(BaseModel):
     conviction_model: str = "consensus"  # consensus | payoff_weighted | barbell
     allow_contested_ideas: bool = False  # let high-upside/low-agreement ideas survive
     require_quantified_levels: bool = True  # force entry/target/stop on every insight
+    # Favor names with strong recent momentum / relative strength (recent winners)
+    # over laggards hoping to mean-revert. Steers selection + synthesis.
+    favor_momentum: bool = False
+    # Steer away from slow mega-cap financials/staples/utilities/mega-banks that
+    # rarely deliver the upside an aggressive mandate targets (unless a sharp catalyst).
+    avoid_slow_megacaps: bool = False
     tiers: list[PolicyTier] = Field(default_factory=list)
 
     # --- Guardrails ---
@@ -118,6 +124,8 @@ _AGGRESSIVE = ResearchPolicy(
     conviction_model="barbell",
     allow_contested_ideas=True,
     require_quantified_levels=True,
+    favor_momentum=True,
+    avoid_slow_megacaps=True,
     tail_risk_override_pct=30.0,  # tolerate more tail risk for convexity
     max_position_pct=5.0,
     tiers=[
@@ -164,10 +172,13 @@ _BEST_BETS = ResearchPolicy(
         "the top 1-3 names with the best expected upside over a ~1-2 week window."
     ),
     objective="best_bets",
-    risk_appetite=0.85,
-    # Over ~2 weeks you cannot demand 3:1; ask for a favorable but realistic skew.
+    risk_appetite=0.95,
     min_reward_risk=2.0,
-    target_upside_pct=8.0,  # a strong 1-2 week move, not a multi-month re-rating
+    # Demand REAL upside, not a safe single-digit gain. A high bar forces the
+    # ranker toward high-beta / catalyst / momentum names rather than sleepy
+    # mega-caps that can only plausibly creep ~8%. Horizon may extend past two
+    # weeks when a materially larger move warrants it.
+    target_upside_pct=25.0,
     time_horizon_bias="short_term",
     max_total_insights=3,  # the whole point: at most 3, ranked best-first
     include_small_mid_cap=True,
@@ -176,12 +187,14 @@ _BEST_BETS = ResearchPolicy(
     conviction_model="payoff_weighted",
     allow_contested_ideas=True,
     require_quantified_levels=True,
-    tail_risk_override_pct=20.0,
+    favor_momentum=True,
+    avoid_slow_megacaps=True,
+    tail_risk_override_pct=25.0,
     max_position_pct=6.0,
     tiers=[
         PolicyTier(name="top_pick", label="Top Pick", min_reward_risk=2.0,
                    max_count=3, position_size_pct="3-6%",
-                   note="Highest expected near-term upside; ranked best-first."),
+                   note="Highest expected upside magnitude; ranked best-first."),
     ],
 )
 
@@ -294,6 +307,18 @@ def _render_selection(policy: ResearchPolicy) -> str:
         lines.append(f"- Exclude sectors: {', '.join(policy.exclude_sectors)}.")
     if "catalyst_calendar" in policy.candidate_sources:
         lines.append("- Prioritize names with a known catalyst (earnings, regulatory, product) on the horizon.")
+    if policy.favor_momentum:
+        lines.append(
+            "- Favor names already showing STRONG recent momentum / relative strength "
+            "(recent winners, breakouts, accelerating volume) — not beaten-down laggards "
+            "hoping to mean-revert."
+        )
+    if policy.avoid_slow_megacaps:
+        lines.append(
+            "- AVOID slow mega-cap financials, banks, staples, and utilities (e.g. big-bank "
+            "names like MS/GS/JPM, telecoms, utilities) unless a sharp near-term catalyst is "
+            "present — they rarely deliver the upside this mandate targets."
+        )
     horizon = _horizon_phrase(policy)
     if horizon:
         lines.append(f"- {horizon}")
@@ -307,8 +332,10 @@ def _render_synthesis(policy: ResearchPolicy) -> str:
             "bets alongside a thin defensive core. Do NOT blend them into one mushy middle."
         ),
         "payoff_weighted": (
-            "Rank ideas by asymmetric payoff (upside-to-target ÷ downside-to-stop), "
-            "not by how many analysts agree."
+            "Rank ideas by EXPECTED UPSIDE MAGNITUDE first (probability-weighted % to "
+            "target), using downside-to-stop as the tiebreaker. Do NOT optimize for the "
+            "'safest' or most-consensus setup — a modest, low-variance gain is NOT a best "
+            "bet. Reward names with the largest credible move."
         ),
         "consensus": (
             "Favor ideas with strong multi-analyst agreement and clear risk/reward."
@@ -340,6 +367,18 @@ def _render_synthesis(policy: ResearchPolicy) -> str:
         f"**Risk veto:** only let a risk warning override a bullish thesis when tail-risk "
         f"probability exceeds {policy.tail_risk_override_pct:.0f}%."
     )
+    if policy.favor_momentum:
+        lines.append(
+            "**Momentum:** prefer names with strong recent relative strength (recent "
+            "winners/breakouts). A name with weak recent performance is rarely a best bet "
+            "unless a fresh catalyst clearly re-rates it."
+        )
+    if policy.avoid_slow_megacaps:
+        lines.append(
+            "**Avoid slow mega-caps:** do not surface sleepy mega-cap banks/financials, "
+            "staples, or utilities (MS, GS, JPM, telecoms, utilities) as a top pick unless a "
+            "sharp near-term catalyst is driving an outsized move — they cap the upside."
+        )
     horizon = _horizon_phrase(policy)
     if horizon:
         lines.append(f"**Holding window:** {horizon}")

--- a/backend/analysis/research_policy.py
+++ b/backend/analysis/research_policy.py
@@ -41,10 +41,17 @@ class ResearchPolicy(BaseModel):
     description: str = ""
 
     # --- Objective: what we optimize for ---
-    objective: str = "balanced"  # asymmetric_upside | balanced | capital_preservation | income
+    objective: str = "balanced"  # asymmetric_upside | balanced | capital_preservation | income | best_bets
     risk_appetite: float = Field(0.5, ge=0.0, le=1.0)  # variance tolerance
     min_reward_risk: float = 2.0  # floor R:R to call something an "opportunity"
     target_upside_pct: float = 25.0  # min bull-case upside for the top tier
+    # Holding-window bias: "short_term" (~1-2 weeks), "medium_term" (~1-3 months),
+    # "long_term" (quarters+), or "any". Steers selection + synthesis emphasis.
+    time_horizon_bias: str = "any"
+    # Hard ceiling on the total number of insights produced. None = no cap (use
+    # the caller's max_insights). Set this for concentrated "best bets" modes
+    # that should return only the top N ranked names from a wider analyzed field.
+    max_total_insights: int | None = None
 
     # --- Universe: where we hunt ---
     include_small_mid_cap: bool = False
@@ -150,8 +157,36 @@ _DEFENSIVE = ResearchPolicy(
     ],
 )
 
+_BEST_BETS = ResearchPolicy(
+    name="best_bets",
+    description=(
+        "Concentrated conviction mode: rank a wide analyzed field and return only "
+        "the top 1-3 names with the best expected upside over a ~1-2 week window."
+    ),
+    objective="best_bets",
+    risk_appetite=0.85,
+    # Over ~2 weeks you cannot demand 3:1; ask for a favorable but realistic skew.
+    min_reward_risk=2.0,
+    target_upside_pct=8.0,  # a strong 1-2 week move, not a multi-month re-rating
+    time_horizon_bias="short_term",
+    max_total_insights=3,  # the whole point: at most 3, ranked best-first
+    include_small_mid_cap=True,
+    asset_classes=["equity", "adr", "commodity"],
+    candidate_sources=["heatmap", "movers", "unusual_volume", "catalyst_calendar"],
+    conviction_model="payoff_weighted",
+    allow_contested_ideas=True,
+    require_quantified_levels=True,
+    tail_risk_override_pct=20.0,
+    max_position_pct=6.0,
+    tiers=[
+        PolicyTier(name="top_pick", label="Top Pick", min_reward_risk=2.0,
+                   max_count=3, position_size_pct="3-6%",
+                   note="Highest expected near-term upside; ranked best-first."),
+    ],
+)
+
 PRESETS: dict[str, ResearchPolicy] = {
-    p.name: p for p in (_BALANCED, _AGGRESSIVE, _DEFENSIVE)
+    p.name: p for p in (_BALANCED, _AGGRESSIVE, _DEFENSIVE, _BEST_BETS)
 }
 
 DEFAULT_POLICY_NAME = "balanced"
@@ -211,6 +246,22 @@ def render_policy_directives(policy: ResearchPolicy, phase: str) -> str:
     return _render_synthesis(policy)
 
 
+_HORIZON_PHRASES = {
+    "short_term": (
+        "Optimize for a SHORT ~1-2 week holding window. Weight imminent catalysts "
+        "(earnings/events within ~10 trading days), short-term momentum, and clean "
+        "technical setups near actionable levels. De-emphasize slow multi-quarter "
+        "fundamental theses that need months to play out."
+    ),
+    "medium_term": "Optimize for a ~1-3 month holding window.",
+    "long_term": "Optimize for a multi-quarter holding window; tolerate slow theses.",
+}
+
+
+def _horizon_phrase(policy: ResearchPolicy) -> str | None:
+    return _HORIZON_PHRASES.get(policy.time_horizon_bias)
+
+
 def _render_selection(policy: ResearchPolicy) -> str:
     lines = [
         f"## Research Mandate: {policy.name} ({policy.objective})",
@@ -243,6 +294,9 @@ def _render_selection(policy: ResearchPolicy) -> str:
         lines.append(f"- Exclude sectors: {', '.join(policy.exclude_sectors)}.")
     if "catalyst_calendar" in policy.candidate_sources:
         lines.append("- Prioritize names with a known catalyst (earnings, regulatory, product) on the horizon.")
+    horizon = _horizon_phrase(policy)
+    if horizon:
+        lines.append(f"- {horizon}")
     return "\n".join(lines)
 
 
@@ -286,6 +340,18 @@ def _render_synthesis(policy: ResearchPolicy) -> str:
         f"**Risk veto:** only let a risk warning override a bullish thesis when tail-risk "
         f"probability exceeds {policy.tail_risk_override_pct:.0f}%."
     )
+    horizon = _horizon_phrase(policy)
+    if horizon:
+        lines.append(f"**Holding window:** {horizon}")
+    if policy.max_total_insights:
+        n = policy.max_total_insights
+        lines.append(
+            f"**CONCENTRATED OUTPUT — return AT MOST {n} insight(s).** You analyzed a wide "
+            f"field so you could RANK it: surface ONLY the {n} names with the highest "
+            f"expected payoff over the holding window, best-first. Quality and ranking "
+            f"beat coverage — if only 1-2 names truly stand out, return just those; never "
+            f"pad to {n}. Order the `insights` array best-first."
+        )
 
     if policy.tiers:
         lines.append("")

--- a/backend/analysis/research_policy.py
+++ b/backend/analysis/research_policy.py
@@ -1,0 +1,304 @@
+"""Research policy — the declarative objective function for autonomous discovery.
+
+A ``ResearchPolicy`` defines *what the pipeline is optimizing for* (asymmetric
+upside vs. balanced vs. capital preservation) and the guardrails around it. The
+objective lives here as data, not hardcoded in agent prompts, so the same engine
+can produce very different idea sheets by swapping the active policy.
+
+The policy drives the pipeline two ways:
+  1. Rendered directives — ``render_policy_directives(policy, phase)`` produces a
+     mandate block injected into the selection and synthesis contexts, so every
+     agent shares one objective.
+  2. Numeric gates — fields like ``min_reward_risk``, ``tiers`` and
+     ``tail_risk_override_pct`` are read directly in engine code.
+
+Resolution order (see ``build_policy``): per-run override → active policy stored
+in ``user_settings['research_policy']`` → built-in default preset (env-selectable).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class PolicyTier(BaseModel):
+    """One output bucket. Insights are labeled with a tier ``name``."""
+
+    name: str
+    label: str
+    min_reward_risk: float = 0.0  # min upside:downside to qualify for this tier
+    max_count: int = 5
+    position_size_pct: str = "1-3%"
+    note: str = ""
+
+
+class ResearchPolicy(BaseModel):
+    """Declarative objective + guardrails for an autonomous discovery run."""
+
+    name: str = "balanced"
+    description: str = ""
+
+    # --- Objective: what we optimize for ---
+    objective: str = "balanced"  # asymmetric_upside | balanced | capital_preservation | income
+    risk_appetite: float = Field(0.5, ge=0.0, le=1.0)  # variance tolerance
+    min_reward_risk: float = 2.0  # floor R:R to call something an "opportunity"
+    target_upside_pct: float = 25.0  # min bull-case upside for the top tier
+
+    # --- Universe: where we hunt ---
+    include_small_mid_cap: bool = False
+    market_cap_floor_b: float | None = None  # $B floor; None = no floor
+    asset_classes: list[str] = Field(default_factory=lambda: ["equity", "adr", "commodity"])
+    candidate_sources: list[str] = Field(default_factory=lambda: ["heatmap"])
+    exclude_sectors: list[str] = Field(default_factory=list)
+
+    # --- Conviction & output shape ---
+    conviction_model: str = "consensus"  # consensus | payoff_weighted | barbell
+    allow_contested_ideas: bool = False  # let high-upside/low-agreement ideas survive
+    require_quantified_levels: bool = True  # force entry/target/stop on every insight
+    tiers: list[PolicyTier] = Field(default_factory=list)
+
+    # --- Guardrails ---
+    tail_risk_override_pct: float = 15.0  # risk veto only above this tail-risk prob
+    max_position_pct: float = 7.0
+
+    def tier_names(self) -> list[str]:
+        return [t.name for t in self.tiers]
+
+
+# ---------------------------------------------------------------------------
+# Built-in presets
+# ---------------------------------------------------------------------------
+
+_BALANCED = ResearchPolicy(
+    name="balanced",
+    description="Mix of asymmetric opportunities and steady core ideas. Default.",
+    objective="balanced",
+    risk_appetite=0.5,
+    min_reward_risk=2.0,
+    target_upside_pct=25.0,
+    include_small_mid_cap=False,
+    asset_classes=["equity", "adr", "commodity"],
+    candidate_sources=["heatmap"],
+    conviction_model="payoff_weighted",
+    allow_contested_ideas=False,
+    require_quantified_levels=True,
+    tail_risk_override_pct=15.0,
+    max_position_pct=7.0,
+    tiers=[
+        PolicyTier(name="high_conviction", label="High-Conviction", min_reward_risk=2.5,
+                   max_count=4, position_size_pct="4-6%", note="Strong multi-signal setups."),
+        PolicyTier(name="opportunistic", label="Opportunistic", min_reward_risk=1.5,
+                   max_count=4, position_size_pct="2-4%", note="Promising but earlier or contested."),
+        PolicyTier(name="core", label="Defensive Core", min_reward_risk=0.0,
+                   max_count=3, position_size_pct="3-5%", note="Lower-variance ballast / income."),
+    ],
+)
+
+_AGGRESSIVE = ResearchPolicy(
+    name="aggressive_asymmetric",
+    description="Hunt high-stakes, high-upside asymmetric bets. Variance is the price of convexity.",
+    objective="asymmetric_upside",
+    risk_appetite=0.9,
+    min_reward_risk=3.0,
+    target_upside_pct=50.0,
+    include_small_mid_cap=True,
+    market_cap_floor_b=None,
+    asset_classes=["equity", "adr", "commodity"],
+    candidate_sources=["heatmap", "catalyst_calendar", "high_short_interest",
+                       "unusual_volume", "52w_extremes", "movers"],
+    conviction_model="barbell",
+    allow_contested_ideas=True,
+    require_quantified_levels=True,
+    tail_risk_override_pct=30.0,  # tolerate more tail risk for convexity
+    max_position_pct=5.0,
+    tiers=[
+        PolicyTier(name="asymmetric", label="High-Conviction Asymmetric", min_reward_risk=3.0,
+                   max_count=5, position_size_pct="2-4%",
+                   note="Small-sized, high-variance bets with a credible 2-5x / sharp re-rating path."),
+        PolicyTier(name="thematic", label="Thematic / Swing", min_reward_risk=2.0,
+                   max_count=4, position_size_pct="2-3%",
+                   note="Catalyst-driven swings riding a live theme."),
+        PolicyTier(name="core", label="Defensive Core", min_reward_risk=0.0,
+                   max_count=2, position_size_pct="3-5%",
+                   note="Minimal ballast only — this mandate is about the satellites, not the core."),
+    ],
+)
+
+_DEFENSIVE = ResearchPolicy(
+    name="defensive_income",
+    description="Capital preservation and income; favor low-variance, quality, dividend names.",
+    objective="capital_preservation",
+    risk_appetite=0.2,
+    min_reward_risk=1.5,
+    target_upside_pct=12.0,
+    include_small_mid_cap=False,
+    market_cap_floor_b=10.0,
+    asset_classes=["equity", "commodity"],
+    candidate_sources=["heatmap"],
+    conviction_model="consensus",
+    allow_contested_ideas=False,
+    require_quantified_levels=True,
+    tail_risk_override_pct=10.0,  # quick to veto on tail risk
+    max_position_pct=8.0,
+    tiers=[
+        PolicyTier(name="core", label="Quality Core", min_reward_risk=1.5,
+                   max_count=6, position_size_pct="4-7%", note="Durable, lower-beta compounders."),
+        PolicyTier(name="income", label="Income", min_reward_risk=0.0,
+                   max_count=4, position_size_pct="3-6%", note="Yield with capital stability."),
+    ],
+)
+
+PRESETS: dict[str, ResearchPolicy] = {
+    p.name: p for p in (_BALANCED, _AGGRESSIVE, _DEFENSIVE)
+}
+
+DEFAULT_POLICY_NAME = "balanced"
+
+
+def get_preset(name: str | None) -> ResearchPolicy:
+    """Return a copy of a named preset, falling back to the default."""
+    preset = PRESETS.get((name or "").strip()) or PRESETS[DEFAULT_POLICY_NAME]
+    return preset.model_copy(deep=True)
+
+
+def build_policy(
+    override: str | dict[str, Any] | None = None,
+    active_setting: str | dict[str, Any] | None = None,
+    env_default: str | None = None,
+) -> ResearchPolicy:
+    """Resolve the effective policy (pure; no I/O).
+
+    Precedence: ``override`` (per-run) → ``active_setting`` (user_settings) →
+    ``env_default`` preset name → built-in default.
+
+    Each of ``override`` / ``active_setting`` may be:
+      * a preset name (str), or
+      * a dict of field overrides, optionally with ``{"base": "<preset>"}`` to
+        choose the preset the overrides are layered onto.
+    """
+    chosen = override if override is not None else active_setting
+
+    if isinstance(chosen, str) and chosen.strip():
+        return get_preset(chosen)
+
+    if isinstance(chosen, dict) and chosen:
+        base_name = chosen.get("base") or env_default or DEFAULT_POLICY_NAME
+        base = get_preset(base_name)
+        patch = {k: v for k, v in chosen.items() if k != "base" and v is not None}
+        return base.model_copy(update=patch, deep=True)
+
+    return get_preset(env_default or DEFAULT_POLICY_NAME)
+
+
+# ---------------------------------------------------------------------------
+# Rendered directives — injected into agent contexts
+# ---------------------------------------------------------------------------
+
+def render_policy_directives(policy: ResearchPolicy, phase: str) -> str:
+    """Render the policy into a markdown mandate block for a pipeline phase.
+
+    Args:
+        policy: The resolved research policy.
+        phase: ``"selection"`` (heatmap stock picking) or ``"synthesis"``.
+
+    Returns:
+        Markdown directive block (never empty).
+    """
+    if phase == "selection":
+        return _render_selection(policy)
+    return _render_synthesis(policy)
+
+
+def _render_selection(policy: ResearchPolicy) -> str:
+    lines = [
+        f"## Research Mandate: {policy.name} ({policy.objective})",
+        policy.description,
+        "",
+        "Apply this mandate when choosing which names to deep-dive:",
+        f"- Risk appetite: {policy.risk_appetite:.0%}. "
+        + (
+            "Favor high-variance, catalyst-rich names with large potential moves over tidy, low-beta setups."
+            if policy.risk_appetite >= 0.66
+            else "Favor durable, lower-variance quality names."
+            if policy.risk_appetite <= 0.33
+            else "Balance opportunity against stability."
+        ),
+        f"- Score candidates primarily by POTENTIAL MOVE SIZE and catalyst proximity, "
+        f"targeting setups with at least ~{policy.target_upside_pct:.0f}% upside to a credible target — "
+        f"not merely by how analytically interesting the pattern is.",
+        f"- Asset classes in scope: {', '.join(policy.asset_classes)}.",
+    ]
+    if policy.include_small_mid_cap:
+        lines.append(
+            "- Small- and mid-cap names are IN SCOPE and encouraged — that is where "
+            "asymmetric upside often lives. Do not restrict to mega-caps."
+        )
+    else:
+        lines.append("- Prefer liquid large-cap names.")
+    if policy.market_cap_floor_b:
+        lines.append(f"- Avoid names below ~${policy.market_cap_floor_b:.0f}B market cap.")
+    if policy.exclude_sectors:
+        lines.append(f"- Exclude sectors: {', '.join(policy.exclude_sectors)}.")
+    if "catalyst_calendar" in policy.candidate_sources:
+        lines.append("- Prioritize names with a known catalyst (earnings, regulatory, product) on the horizon.")
+    return "\n".join(lines)
+
+
+def _render_synthesis(policy: ResearchPolicy) -> str:
+    model_line = {
+        "barbell": (
+            "Construct a BARBELL: a handful of genuinely asymmetric, small-sized high-upside "
+            "bets alongside a thin defensive core. Do NOT blend them into one mushy middle."
+        ),
+        "payoff_weighted": (
+            "Rank ideas by asymmetric payoff (upside-to-target ÷ downside-to-stop), "
+            "not by how many analysts agree."
+        ),
+        "consensus": (
+            "Favor ideas with strong multi-analyst agreement and clear risk/reward."
+        ),
+    }.get(policy.conviction_model, "Rank ideas by risk-adjusted payoff.")
+
+    lines = [
+        f"## Research Mandate: {policy.name} ({policy.objective})",
+        policy.description,
+        "",
+        f"**Objective:** {model_line}",
+        f"**Payoff floor:** An idea only qualifies as a top-tier opportunity when its "
+        f"reward:risk ≥ {policy.min_reward_risk:.1f} and the bull-case upside ≥ "
+        f"{policy.target_upside_pct:.0f}%.",
+    ]
+    if policy.require_quantified_levels:
+        lines.append(
+            "**Quantified levels are REQUIRED:** every insight MUST include `entry_zone`, "
+            "`target` (with an explicit % to target), and `stop_loss`. Express the payoff. "
+            "An insight without quantified levels is incomplete."
+        )
+    if policy.allow_contested_ideas:
+        lines.append(
+            "**Contested ideas are welcome:** a high-upside thesis that some analysts doubt is "
+            "still valid — the edge lives where there is disagreement. Do NOT demote it to WATCH "
+            "for lack of consensus; reflect the doubt in `risk_factors` and size it smaller instead."
+        )
+    lines.append(
+        f"**Risk veto:** only let a risk warning override a bullish thesis when tail-risk "
+        f"probability exceeds {policy.tail_risk_override_pct:.0f}%."
+    )
+
+    if policy.tiers:
+        lines.append("")
+        lines.append(
+            "**Assign every insight a `tier`** (string field) from the buckets below, "
+            "and size per the tier guidance:"
+        )
+        for t in policy.tiers:
+            rr = f" — requires reward:risk ≥ {t.min_reward_risk:.1f}" if t.min_reward_risk else ""
+            lines.append(
+                f"- `{t.name}` ({t.label}, up to {t.max_count}, size {t.position_size_pct}){rr}: {t.note}"
+            )
+    lines.append(
+        f"\nKeep position sizes at or below {policy.max_position_pct:.0f}% of portfolio per name."
+    )
+    return "\n".join(lines)

--- a/backend/api/routes/deep_insights.py
+++ b/backend/api/routes/deep_insights.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 from datetime import datetime
+from typing import Any
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -38,6 +39,12 @@ class AutonomousAnalysisRequest(BaseModel):
     max_insights: int = Field(default=10, ge=1, le=20, description="Number of final insights to produce")
     deep_dive_count: int = Field(default=12, ge=1, le=30, description="Number of opportunities to analyze in detail")
     include_quant_signals: bool = Field(default=True, description="Run IC-calibrated quant scorer and inject scores as additional context")
+    policy: str | dict[str, Any] | None = Field(
+        default=None,
+        description="Per-run research-policy override: a preset name (e.g. 'aggressive_asymmetric') "
+        "or a dict of field overrides (optionally with {'base': '<preset>'}). Falls back to the "
+        "active policy in settings, then the env default.",
+    )
 
 
 class AutonomousAnalysisResponse(BaseModel):
@@ -289,6 +296,7 @@ async def run_autonomous_analysis(
             max_insights=max_insights,
             deep_dive_count=deep_dive_count,
             quant_context=quant_context,
+            policy=request.policy if request else None,
         )
 
         # Extract top sectors from result
@@ -481,7 +489,12 @@ async def _auto_publish_report(task_id: str) -> None:
         logger.info(f"Auto-published report {task_id} to {published_url}")
 
 
-async def _run_background_analysis(task_id: str, max_insights: int, deep_dive_count: int) -> None:
+async def _run_background_analysis(
+    task_id: str,
+    max_insights: int,
+    deep_dive_count: int,
+    policy: str | dict[str, Any] | None = None,
+) -> None:
     """Background task to run autonomous analysis with progress updates.
 
     Delegates to the shared runner in ``analysis.autonomous_runner`` so
@@ -499,6 +512,7 @@ async def _run_background_analysis(task_id: str, max_insights: int, deep_dive_co
         task_id=task_id,
         max_insights=max_insights,
         deep_dive_count=deep_dive_count,
+        policy=policy,
     )
 
 
@@ -521,6 +535,7 @@ async def start_autonomous_analysis(
     """
     max_insights = request.max_insights if request else 5
     deep_dive_count = request.deep_dive_count if request else 7
+    policy = request.policy if request else None
 
     # Create task record
     task_id = str(uuid4())
@@ -552,6 +567,7 @@ async def start_autonomous_analysis(
             task_id=task_id,
             max_insights=max_insights,
             deep_dive_count=deep_dive_count,
+            policy=policy,
         )
     )
     _detached_analysis_tasks.add(analysis_task)

--- a/backend/config.py
+++ b/backend/config.py
@@ -81,6 +81,11 @@ class Settings(BaseSettings):
     PREDICTION_MARKETS_ENABLED: bool = True
     REDDIT_SENTIMENT_ENABLED: bool = True
     NEWS_SENTIMENT_ENABLED: bool = True  # Financial-news sentiment augmentation for deep analysis
+    # Default research policy (objective function) for autonomous discovery.
+    # One of the preset names in analysis.research_policy.PRESETS. The active
+    # policy in user_settings['research_policy'] and a per-run override both
+    # take precedence over this default.
+    RESEARCH_POLICY_DEFAULT: str = "balanced"
     POLYMARKET_RATE_LIMIT: int = 30  # Max requests/minute to Polymarket APIs
     KALSHI_RATE_LIMIT: int = 20  # Max requests/minute to Kalshi API
 

--- a/backend/models/analysis_task.py
+++ b/backend/models/analysis_task.py
@@ -211,6 +211,13 @@ class AnalysisTask(TimestampMixin, Base):
         nullable=True,
     )  # JSON: {"factor_scores": {...}, "correlation_highlights": {...}, "catalyst_data": [...]}
 
+    # Resolved research policy (objective function) this run executed under,
+    # stored as a JSON blob so runs can be compared like-for-like by mandate.
+    research_policy: Mapped[Optional[str]] = mapped_column(
+        Text,
+        nullable=True,
+    )
+
     __table_args__ = (
         Index("ix_analysis_tasks_status_created", "status", "created_at"),
         Index("ix_analysis_tasks_started_at", "started_at"),

--- a/backend/models/deep_insight.py
+++ b/backend/models/deep_insight.py
@@ -132,6 +132,12 @@ class DeepInsight(TimestampMixin, Base):
         String(50),
         nullable=True,
     )  # e.g., "$142 (-5%)"
+    # Research-policy tier this insight was bucketed into (e.g. "asymmetric",
+    # "thematic", "core"). Set by the synthesis lead under the active policy.
+    tier: Mapped[str | None] = mapped_column(
+        String(40),
+        nullable=True,
+    )
     timeframe: Mapped[str | None] = mapped_column(
         String(30),
         nullable=True,

--- a/backend/schemas/deep_insight.py
+++ b/backend/schemas/deep_insight.py
@@ -98,6 +98,7 @@ class DeepInsightResponse(DeepInsightBase):
     entry_zone: Optional[str] = None
     target_price: Optional[str] = None
     stop_loss: Optional[str] = None
+    tier: Optional[str] = None  # research-policy tier (e.g. "asymmetric", "core")
     timeframe: Optional[str] = None
     discovery_context: Optional[dict] = None
 

--- a/backend/tests/test_flatten_analyst_reports.py
+++ b/backend/tests/test_flatten_analyst_reports.py
@@ -1,0 +1,70 @@
+"""Tests for AutonomousDeepEngine._flatten_analyst_reports.
+
+Regression: a discovery run produced only a single insight because the
+flattener pre-seeded `macro` and `correlation` analyst buckets at 0.0
+confidence even though the engine only runs technical/sector/risk per
+symbol. format_synthesis_context then rendered empty "0% confidence"
+macro/correlation reports, and the synthesis LLM read that as "incomplete
+coverage" and collapsed to one conservative pick. Never-ran analysts must
+be dropped so they cannot signal phantom low-confidence coverage.
+"""
+
+from analysis.autonomous_engine import AutonomousDeepEngine
+
+
+def _engine():
+    return AutonomousDeepEngine()
+
+
+def _per_symbol_reports(symbols):
+    return {
+        sym: {
+            "technical": {"findings": [{"symbol": sym}], "confidence": 0.6},
+            "sector": {"sector_rankings": [], "confidence": 0.55},
+            "risk": {"risk_assessments": [{"symbol": sym}], "confidence": 0.5},
+        }
+        for sym in symbols
+    }
+
+
+def test_drops_never_run_macro_and_correlation():
+    flat = _engine()._flatten_analyst_reports(_per_symbol_reports(["ARM", "ADBE", "T"]))
+    assert set(flat.keys()) == {"technical", "sector", "risk"}
+    assert "macro" not in flat
+    assert "correlation" not in flat
+
+
+def test_keeps_analyst_with_confidence_but_no_list_data():
+    # sector ran (confidence > 0) but produced no rankings — still surfaced.
+    flat = _engine()._flatten_analyst_reports(_per_symbol_reports(["NVDA"]))
+    assert "sector" in flat
+    assert flat["sector"]["confidence"] > 0.0
+
+
+def test_keeps_macro_when_it_actually_ran():
+    reports = {
+        "NVDA": {
+            "technical": {"findings": [{"symbol": "NVDA"}], "confidence": 0.6},
+            "macro": {"market_implications": ["rates falling"], "confidence": 0.7},
+        }
+    }
+    flat = _engine()._flatten_analyst_reports(reports)
+    assert "macro" in flat
+    assert flat["macro"]["confidence"] > 0.0
+
+
+def test_empty_reports_surface_no_analysts():
+    flat = _engine()._flatten_analyst_reports({})
+    assert flat == {}
+
+
+def test_errored_analyst_is_not_surfaced():
+    reports = {
+        "NVDA": {
+            "technical": {"findings": [{"symbol": "NVDA"}], "confidence": 0.6},
+            "risk": {"error": "timeout"},
+        }
+    }
+    flat = _engine()._flatten_analyst_reports(reports)
+    assert "technical" in flat
+    assert "risk" not in flat

--- a/backend/tests/test_insight_economics.py
+++ b/backend/tests/test_insight_economics.py
@@ -1,0 +1,63 @@
+"""Tests for live-price verification of synthesis insights.
+
+Regression: best_bets surfaced SE with a "$215 (+35%)" target while SE traded
+~$91 — the upside % was LLM-asserted against a hallucinated base and never
+recomputed. _verify_insight_economics recomputes upside/R:R from the live price,
+relabels honestly, and (for concentrated policies) drops sub-floor or
+mis-anchored picks and ranks best-first.
+"""
+
+from analysis.autonomous_engine import AutonomousDeepEngine, _parse_price_level
+from analysis.research_policy import get_preset
+
+
+def _ins(sym, target, stop="$10", **extra):
+    return {"primary_symbol": sym, "target_price": target, "stop_loss": stop,
+            "title": "t", "thesis": "y", "confidence": 0.5, **extra}
+
+
+def test_parse_price_level():
+    assert _parse_price_level("$215 (35% upside)") == 215.0
+    assert _parse_price_level("$140 (below support)") == 140.0
+    assert _parse_price_level("$1,250 target") == 1250.0
+    assert _parse_price_level("$880-900") == 880.0       # first of a range
+    assert _parse_price_level("N/A - bearish") is None
+    assert _parse_price_level(None) is None
+
+
+def test_relabels_upside_from_live_price():
+    e = AutonomousDeepEngine()
+    e._policy = get_preset("balanced")  # not concentrated -> no gating, just relabel
+    out = e._verify_insight_economics([_ins("ARM", "$270 (28% upside)", "$188")], {"ARM": 150.0})
+    assert out[0]["_verified_upside_pct"] == 80.0   # 270/150 - 1
+    assert "live $150" in out[0]["target_price"]
+
+
+def test_concentrated_drops_mis_anchored_short_horizon():
+    e = AutonomousDeepEngine()
+    e._policy = get_preset("best_bets")  # short_term, cap 3, floor 25%
+    out = e._verify_insight_economics(
+        [_ins("SE", "$215 (35% upside)", "$140")], {"SE": 91.28}
+    )
+    # 215 vs 91.28 = +135%, implausible for a ~2-week window -> dropped
+    assert out == []
+
+
+def test_concentrated_drops_below_floor_and_ranks():
+    e = AutonomousDeepEngine()
+    e._policy = get_preset("best_bets")  # floor 25%, drop below ~15%
+    ins = [
+        _ins("LOW", "$104", "$95"),    # +4% vs 100 -> below floor, dropped
+        _ins("MID", "$130", "$90"),    # +30% vs 100 -> kept
+        _ins("HIGH", "$150", "$92"),   # +50% vs 100 -> kept, ranks first
+    ]
+    out = e._verify_insight_economics(ins, {"LOW": 100.0, "MID": 100.0, "HIGH": 100.0})
+    assert [i["primary_symbol"] for i in out] == ["HIGH", "MID"]
+
+
+def test_missing_live_price_is_kept_not_dropped():
+    e = AutonomousDeepEngine()
+    e._policy = get_preset("best_bets")
+    out = e._verify_insight_economics([_ins("XYZ", "$50")], {})  # no price -> can't verify
+    assert [i["primary_symbol"] for i in out] == ["XYZ"]
+    assert "_verified_upside_pct" not in out[0]

--- a/backend/tests/test_research_policy.py
+++ b/backend/tests/test_research_policy.py
@@ -1,0 +1,64 @@
+"""Tests for the research-policy objective layer."""
+
+from analysis.research_policy import (
+    PRESETS,
+    DEFAULT_POLICY_NAME,
+    build_policy,
+    get_preset,
+    render_policy_directives,
+)
+from analysis.autonomous_engine import AutonomousDeepEngine
+
+
+def test_presets_exist():
+    assert {"balanced", "aggressive_asymmetric", "defensive_income"} <= set(PRESETS)
+
+
+def test_get_preset_returns_copy_and_falls_back():
+    a = get_preset("aggressive_asymmetric")
+    a.min_reward_risk = 99.0
+    assert get_preset("aggressive_asymmetric").min_reward_risk == 3.0  # original untouched
+    assert get_preset("does_not_exist").name == DEFAULT_POLICY_NAME
+
+
+def test_build_policy_precedence_override_wins():
+    p = build_policy(override="aggressive_asymmetric", active_setting="defensive_income", env_default="balanced")
+    assert p.name == "aggressive_asymmetric"
+
+
+def test_build_policy_active_setting_when_no_override():
+    p = build_policy(override=None, active_setting="defensive_income", env_default="balanced")
+    assert p.name == "defensive_income"
+
+
+def test_build_policy_env_default_when_nothing_set():
+    assert build_policy(None, None, "aggressive_asymmetric").name == "aggressive_asymmetric"
+    assert build_policy(None, None, None).name == DEFAULT_POLICY_NAME
+
+
+def test_build_policy_dict_override_layers_on_base():
+    p = build_policy(override={"base": "balanced", "target_upside_pct": 40, "allow_contested_ideas": True})
+    assert p.name == "balanced"  # base preset identity preserved
+    assert p.target_upside_pct == 40
+    assert p.allow_contested_ideas is True
+
+
+def test_aggressive_directives_carry_asymmetry_language():
+    p = get_preset("aggressive_asymmetric")
+    sel = render_policy_directives(p, "selection")
+    syn = render_policy_directives(p, "synthesis")
+    assert "asymmetric" in syn.lower()
+    assert "barbell" in syn.lower()
+    assert "reward:risk" in syn.lower()
+    assert "small- and mid-cap" in sel.lower()
+    # required quantified levels surfaced
+    assert "entry_zone" in syn
+
+
+def test_normalize_tier_maps_to_policy_names():
+    e = AutonomousDeepEngine()
+    e._policy = get_preset("aggressive_asymmetric")
+    assert e._normalize_tier("Asymmetric") == "asymmetric"
+    assert e._normalize_tier("high-conviction asymmetric") in {"asymmetric", "high-conviction asymmetric"}
+    assert e._normalize_tier("  ") is None
+    assert e._normalize_tier("unknown_bucket") == "unknown_bucket"  # raw passthrough

--- a/backend/tests/test_research_policy.py
+++ b/backend/tests/test_research_policy.py
@@ -55,6 +55,35 @@ def test_aggressive_directives_carry_asymmetry_language():
     assert "entry_zone" in syn
 
 
+def test_best_bets_is_concentrated_short_horizon():
+    p = get_preset("best_bets")
+    assert p.max_total_insights == 3
+    assert p.time_horizon_bias == "short_term"
+    syn = render_policy_directives(p, "synthesis")
+    sel = render_policy_directives(p, "selection")
+    assert "AT MOST 3" in syn          # hard ceiling, not a floor
+    assert "1-2 week" in syn           # short holding window
+    assert "1-2 week" in sel
+
+
+def test_count_guidance_concentrated_vs_floor():
+    e = AutonomousDeepEngine()
+    e._policy = get_preset("best_bets")
+    target, count = e._synthesis_count_guidance(10, 3)
+    assert "TOP 3" in target
+    assert "Returning fewer is fine" in count and "AT LEAST" not in count
+    # default policy keeps the floor behavior
+    e._policy = get_preset("balanced")
+    _, count2 = e._synthesis_count_guidance(7, 10)
+    assert "AT LEAST" in count2
+
+
+def test_concentrated_clamp_logic():
+    p = get_preset("best_bets")
+    assert min(10, p.max_total_insights) == 3
+    assert min(2, p.max_total_insights) == 2  # caller asking for fewer wins
+
+
 def test_normalize_tier_maps_to_policy_names():
     e = AutonomousDeepEngine()
     e._policy = get_preset("aggressive_asymmetric")

--- a/backend/tests/test_research_policy.py
+++ b/backend/tests/test_research_policy.py
@@ -66,6 +66,21 @@ def test_best_bets_is_concentrated_short_horizon():
     assert "1-2 week" in sel
 
 
+def test_best_bets_chases_upside_not_safety():
+    # Regression: best_bets surfaced a sleepy mega-cap bank (MS, +16%) because the
+    # upside bar was too low and the objective was "risk-adjusted/safe". It must
+    # now demand real upside, chase momentum, and avoid slow mega-caps.
+    p = get_preset("best_bets")
+    assert p.target_upside_pct >= 20.0          # not the old 8%
+    assert p.favor_momentum is True
+    assert p.avoid_slow_megacaps is True
+    syn = render_policy_directives(p, "synthesis")
+    sel = render_policy_directives(p, "selection")
+    assert "EXPECTED UPSIDE MAGNITUDE" in syn    # magnitude-first ranking
+    assert "Avoid slow mega-caps" in syn and "AVOID slow mega-cap" in sel
+    assert "momentum" in syn.lower() and "momentum" in sel.lower()
+
+
 def test_count_guidance_concentrated_vs_floor():
     e = AutonomousDeepEngine()
     e._policy = get_preset("best_bets")


### PR DESCRIPTION
## Summary

Makes the autonomous discovery objective a declarative **research policy** instead of hardcoding it in agent prompts, adds a concentrated **best_bets** mode (top 1-3 highest-upside short-horizon picks), and fixes several discovery-quality bugs found along the way — including untrustworthy price targets.

## What's in it (4 commits)

**1. Configurable research policy + single-discovery fix** (`e888d65`)
- `analysis/research_policy.py`: `ResearchPolicy` model, presets (`balanced` default, `aggressive_asymmetric`, `defensive_income`), pure resolver, directive renderer.
- Resolution: per-run override (`policy` on `AutonomousAnalysisRequest`) → active `user_settings['research_policy']` → `RESEARCH_POLICY_DEFAULT` env preset.
- Drives the pipeline two ways: rendered directives injected into selection + synthesis, and numeric gates in code (min reward:risk, tiers, quantified levels, tail-risk override). Resolved policy snapshotted on the run; `tier` stored per insight.
- Bug fix: `_flatten_analyst_reports` pre-seeded empty macro/correlation buckets at 0% confidence, making the synthesis LLM read "incomplete coverage" and collapse to a single insight. Never-run analysts are now dropped.

**2. best_bets concentrated short-horizon mode** (`9dde198`)
- New `max_total_insights` (hard ceiling) and `time_horizon_bias` policy levers. `best_bets` ranks a wide deep-dived field and returns only the top 1-3 over a ~1-2 week window. Count guidance is policy-aware (ceiling vs. floor).

**3. Retune best_bets for upside + momentum** (`4997d1f`)
- best_bets was tuned for safety (8% upside bar, "risk-adjusted" objective) and surfaced a sleepy mega-cap (Morgan Stanley, +16%). Now: `target_upside_pct` 8→25, magnitude-first ranking, and new `favor_momentum` + `avoid_slow_megacaps` levers (also on aggressive) that prefer recent winners and steer away from slow mega-cap banks/staples/utilities.

**4. Live-price anchoring + code-side upside verification** (`bd88d08`)
- The displayed upside % was LLM-asserted, and the deep-dive context reads a `price_history` table frozen at 2026-04-30. Result: a "$215 (+35%)" SE target while SE trades ~$91, and ARM priced off a stale $210 vs a live $439.
- `_fetch_live_prices()` injects an authoritative live-price block into synthesis; `_verify_insight_economics()` recomputes upside/R:R from the live price, relabels honestly (`$115 (live $91.28 → +26%)`), drops sub-floor/mis-anchored picks for concentrated policies, and ranks best-first.

## Verification

`best_bets` end-to-end now returns live-anchored picks — e.g. SE $115 (+26%), AMD $675 (+26%), ARM $550 (+25%) — momentum names, real prices, upside computed in code. 50 tests pass across policy, economics, flatten, dedup, parse, and deep-insights suites.

## Notes / follow-ups (not in this PR)

- **Default stays `balanced`**; aggressive/best_bets are opt-in per-run or via settings.
- Base is `feat/news-sentiment` (builds on that branch's news code); retarget to `main` once it merges.
- Deferred: wire the `candidate_sources` the aggressive/best_bets presets declare (universe widening), momentum-ranked deterministic deep-dive ordering, and a bull/bear debate phase.
- Separate infra issue surfaced: the `price_history` ETL ingestion is stale since 2026-04-30 (the live-fetch routes around it for picks, but other views still see stale prices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)